### PR TITLE
Clean up dashboard test

### DIFF
--- a/__tests__/pages/(dashboard)/layout.test.tsx
+++ b/__tests__/pages/(dashboard)/layout.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom'
 import Layout from "@/app/(dashboard)/layout"
 import myGetServerSession from "@/lib/myGetServerSession";
-import {act, ReactNode} from "react";
+import {act} from "react";
 import {notFound} from "next/navigation"
 import fetchRedis from "@/helpers/redis";
-import {render, waitFor, screen} from "@testing-library/react";
+import {render, screen, waitFor} from "@testing-library/react";
+import FriendRequestSidebarOptions from "@/components/friendRequestSidebarOptions/FriendRequestSidebarOptions";
+
+jest.mock("../../../src/components/friendRequestSidebarOptions/FriendRequestSidebarOptions")
 
 jest.mock("../../../src/lib/myGetServerSession",()=>({
     __esModule: true,
@@ -34,122 +37,96 @@ describe('Layout tests',()=>{
         await act(async () => {
             render(<Layout>layout children</Layout>);
         });
-        //await waitFor(() => expect(screen.getByText(/layout children/i)).toBeInTheDocument());
     });
-/**
+
     test('renders children',async ()=>{
-        const testNode = <div>Tossed Salads and Scrambled eggs</div> as ReactNode
-        const layout = await Layout({children:testNode});
-        expect(layout.props.children).toEqual(
-            expect.arrayContaining(
-                [expect.objectContaining({props:
-                        expect.objectContaining({children:'Tossed Salads and Scrambled eggs'})
-                })]));
+        await act(async () => {
+            render(<Layout><div>Tossed Salads and Scrambled eggs</div></Layout>);
+        });
+        expect(screen.getByText('Tossed Salads and Scrambled eggs')).toBeInTheDocument();
     });
 
     test('should call a server session',async ()=>{
-        await Layout();
+        await act(async () => {
+            render(<Layout><div>Tossed Salads and Scrambled eggs</div></Layout>);
+        });
         expect(myGetServerSession).toHaveBeenCalledTimes(1);
     });
 
     test("if it a bad session, then the layout should be notFound",async ()=>{
         (myGetServerSession as jest.Mock).mockResolvedValue(null);
-        await Layout();
+        await act(async () => {
+            render(<Layout><div>Tossed Salads and Scrambled eggs</div></Layout>);
+        })
         expect(notFound).toHaveBeenCalledTimes(1);
     });
 
     test("If it's a fine session, then  notFound should not be called",async ()=>{
-        await Layout();
+        await act(async () => {
+            render(<Layout><div>Tossed Salads and Scrambled eggs</div></Layout>);
+        })
         expect(notFound).not.toHaveBeenCalled();
     });
 
     test("needs to include a Link to dashboard",async ()=>{
-        const layout = await Layout();
-        expect(layout.props.children).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({props:
-                        expect.objectContaining({children:
-                                expect.arrayContaining([
-                                    expect.objectContaining({props:
-                                            expect.objectContaining({href: '/dashboard'})})])})})]))
+        await act(async () => {
+            render(<Layout><div>Tossed Salads and Scrambled eggs</div></Layout>);
+        });
+        const linkElement = screen.getByRole('link', { name: '' });
+        expect(linkElement).toHaveAttribute('href', "/dashboard");
     })
 
     test('Sidebar needs a div called "Your Chats"', async ()=> {
-        const layout = await Layout();
-        expect(layout.props.children).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({props:
-                        expect.objectContaining({children:
-                                expect.arrayContaining([
-                                    expect.objectContaining({props:
-                                            expect.objectContaining({children: 'Your Chats'})})])})})]));
+        await act(async () => {
+            render(<Layout>
+                <div>Tossed Salads and Scrambled eggs</div>
+            </Layout>);
+        });
+        const text = screen.getByText('Your Chats');
+        expect(text).toBeInTheDocument();
     });
 
-    test('Sidebar  a nav for existing chats', async ()=> {
-        const layout = await Layout();
-        expect(layout.props.children).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({props:
-                        expect.objectContaining({children:
-                                expect.arrayContaining([
-                                    expect.objectContaining({type: 'nav'})])})})]))
-    });
-    test('Output of fetchRedis is passed to child component of FriendRequestSidebarOptions.initialRequestCount',
-        async ()=>{
-        const expected: number = 5;
-        (fetchRedis as jest.Mock).mockResolvedValue(['first entry','second entry','third entry','fourth entry','fifth entry'])
-        const layout = await Layout();
-        expect(layout.props.children).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({props:
-                        expect.objectContaining({children:
-                                expect.arrayContaining([
-                                    expect.objectContaining({props:
-                                            expect.objectContaining({children:
-                                                    expect.objectContaining({props:
-                                                            expect.objectContaining({children:
-                                                                    expect.arrayContaining([
-                                                                        expect.objectContaining({props:
-                                                                                expect.objectContaining({children:
-                                                                                        expect.objectContaining({props:
-                                                                                            expect.objectContaining(
-                                                                                                {initialRequestCount:expected}
-                                                                                            )})})})])})})})})])})})]))
+    test('Sidebar a nav for existing chats', async ()=> {
+        render(<Layout>example</Layout>);
+        const navElement = await screen.findByRole('navigation');
+        expect(navElement).toBeInTheDocument();
     });
 
-    test('Output of fetchRedis is passed to child component of FriendRequestSidebarOptions.initialRequestCount, different data',
-        async ()=>{
-        const expected: number = 2;
-        (fetchRedis as jest.Mock).mockResolvedValue(['first entry', 'second entry']);
-        const layout = await Layout()
-        expect(layout.props.children).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({props:
-                        expect.objectContaining({children:
-                                expect.arrayContaining([
-                                    expect.objectContaining({props:
-                                            expect.objectContaining({children:
-                                                    expect.objectContaining({props:
-                                                            expect.objectContaining({children:
-                                                                    expect.arrayContaining([
-                                                                        expect.objectContaining({props:
-                                                                                expect.objectContaining({children:
-                                                                                        expect.objectContaining({props:
-                                                                                                expect.objectContaining(
-                                                                                                    {initialRequestCount:expected}
-                                                                                                )})})})])})})})})])})})]))
+    test('Output of fetchRedis is passed to  FriendRequestSidebarOptions', async ()=>{
+        (fetchRedis as jest.Mock).mockResolvedValue(['first entry','second entry','third entry','fourth entry','fifth entry']);
+        const childComponentSpy = jest.fn();
+        (FriendRequestSidebarOptions as jest.Mock).mockImplementation(({ initialRequestCount }) => {
+                childComponentSpy(initialRequestCount);
+                return <div data-testid="child-component">Mocked Child</div>;
+        });
+        render(<Layout>test</Layout>)
+        await waitFor(() => expect(childComponentSpy).toHaveBeenCalledWith(5));
+    });
+
+    test('Output of fetchRedis is passed to  FriendRequestSidebarOptions, different data', async ()=>{
+        (fetchRedis as jest.Mock).mockResolvedValue(['first entry','second entry']);
+        const childComponentSpy = jest.fn();
+        (FriendRequestSidebarOptions as jest.Mock).mockImplementation(({ initialRequestCount }) => {
+            childComponentSpy(initialRequestCount);
+            return <div data-testid="child-component">Mocked Child</div>;
+        });
+        render(<Layout>test</Layout>)
+        await waitFor(() => expect(childComponentSpy).toHaveBeenCalledWith(2));
     });
 
     test ('confirm input passed to fetchRedis', async ()=>{
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id: '1701'}});
-        await Layout();
-        expect(fetchRedis as jest.Mock).toHaveBeenCalledWith('smembers', 'user:1701:incoming_friend_requests');
+        render(<Layout>test</Layout>)
+        await waitFor(() =>  {
+            expect(fetchRedis as jest.Mock).toHaveBeenCalledWith('smembers', 'user:1701:incoming_friend_requests');
+        });
     });
 
     test ('confirm input passed to fetchRedis', async ()=>{
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id: '45654'}});
-        await Layout();
-        expect(fetchRedis as jest.Mock).toHaveBeenCalledWith('smembers', 'user:45654:incoming_friend_requests');
+        render(<Layout>test</Layout>)
+        await waitFor(() =>  {
+            expect(fetchRedis as jest.Mock).toHaveBeenCalledWith('smembers', 'user:45654:incoming_friend_requests');
+        });
     });
-    **/
 });

--- a/__tests__/pages/(dashboard)/layout.test.tsx
+++ b/__tests__/pages/(dashboard)/layout.test.tsx
@@ -1,9 +1,10 @@
 import '@testing-library/jest-dom'
 import Layout from "@/app/(dashboard)/layout"
 import myGetServerSession from "@/lib/myGetServerSession";
-import {ReactNode} from "react";
+import {act, ReactNode} from "react";
 import {notFound} from "next/navigation"
 import fetchRedis from "@/helpers/redis";
+import {render, waitFor, screen} from "@testing-library/react";
 
 jest.mock("../../../src/lib/myGetServerSession",()=>({
     __esModule: true,
@@ -29,15 +30,13 @@ describe('Layout tests',()=>{
         jest.resetAllMocks();
     });
 
-    test('renders without crashing',async ()=>{
-        try{
-            await Layout();
-        }catch(error){
-            console.error(error);
-            expect(true).toEqual(false);
-        }
+    test('renders without crashing', async () => {
+        await act(async () => {
+            render(<Layout>layout children</Layout>);
+        });
+        //await waitFor(() => expect(screen.getByText(/layout children/i)).toBeInTheDocument());
     });
-
+/**
     test('renders children',async ()=>{
         const testNode = <div>Tossed Salads and Scrambled eggs</div> as ReactNode
         const layout = await Layout({children:testNode});
@@ -152,4 +151,5 @@ describe('Layout tests',()=>{
         await Layout();
         expect(fetchRedis as jest.Mock).toHaveBeenCalledWith('smembers', 'user:45654:incoming_friend_requests');
     });
+    **/
 });


### PR DESCRIPTION
To make the component testable by the react testing library, the async functionality needs to be handled by useEffect. 

I don't like declaring functions inside functions, and useEffect looks like it can get pretty big. But dashboard isn't done yet, and at present, it's of most advantage to have lean, extendable tests, and let cleverer minds make the implementation pretty.