### PR TITLE
Endpoint for accept friend

### DIFF
--- a/__tests__/api/friends/accept/route.test.ts
+++ b/__tests__/api/friends/accept/route.test.ts
@@ -1,18 +1,211 @@
 import { POST } from "@/app/api/friends/accept/route";
+import myGetServerSession from "@/lib/myGetServerSession";
+import fetchRedis from "@/helpers/redis";
+import { db } from '@/lib/db';
+
+jest.mock("../../../../src/lib/myGetServerSession",()=>({
+    __esModule: true,
+    default: jest.fn()
+}));
+
+jest.mock("../../../../src/lib/db",()=>({
+    __esModule: true,
+    db: {
+        sadd: jest.fn(),
+        srem: jest.fn()
+    }
+}));
+
+jest.mock('../../../../src/helpers/redis')
+
+interface expectedResponse {
+    text: string,
+    status: number
+}
 
 describe('/api/friends/accept', () => {
     beforeEach(() => {
-        fetchMock.resetMocks(); // Ensure fresh mocks
+        (fetchRedis as jest.Mock).mockResolvedValue(false);
     });
+
+    afterEach(()=>{
+        jest.resetAllMocks();
+    })
 
     test('POST should run without throwing', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
-
-        const req = new Request('http://localhost/api/friends/accept', {
-            method: 'POST',
-            body: JSON.stringify({ someData: 'value' }),
-            headers: { 'Content-Type': 'application/json' }
-        });
+        const req = requestify('valid')
         await POST(req);
     });
+
+    test('method throws if value is not string', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        const req = requestify(42)
+        const expectedResponse: expectedResponse = {
+            status: 422,
+            text: 'Invalid Request'
+        }
+        const response = await POST(req);
+        assertResponse(response, expectedResponse)
+    });
+
+    test('If session is null, return 401 UnAuthorized', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue(null);
+        const req = requestify('valid')
+        const expected: expectedResponse = {
+            status:401,
+            text: 'Unauthorized'
+        }
+        const response =  await POST(req);
+        assertResponse(response, expected);
+    });
+
+    test('If session is not null, do not return 401 UnAuthorized', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
+        const req = requestify('valid')
+        const response =  await POST(req);
+        const notExpected: expectedResponse = {
+            status: 401,
+            text: 'Unauthorized'
+        }
+        assertNotResponse(response, notExpected);
+    });
+
+    test('fetchRedis(sismember, user:1701:friends is truthy, response should be Already Friends 400', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
+        const req = requestify('valid');
+        (fetchRedis as jest.Mock).mockResolvedValue(true);
+
+        const response =  await POST(req);
+        const expected: expectedResponse = {
+            text: 'Already Friends',
+            status: 400
+        }
+        assertResponse(response, expected)
+    });
+
+    test('fetchRedis(sismember, user:1701:friends is falsy, response should not be Already Friends 400', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
+        const req = requestify('valid');
+        (fetchRedis as jest.Mock).mockResolvedValue(false);
+
+        const response =  await POST(req);
+        const expected: expectedResponse = {
+            text: 'Already Friends',
+            status: 400
+        }
+        assertNotResponse(response, expected)
+    });
+
+    test('fetchRedis should be called with sismember, user:1701:friends, 5468  ', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
+        const req = requestify('5468');
+        await POST(req);
+        expect(fetchRedis as jest.Mock).toHaveBeenCalledWith('sismember','user:1701:friends', '5468');
+    });
+
+    test('fetchRedis should be called with sismember, user:1966:friends, 1701 ', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
+        const req = requestify('1701');
+        await POST(req);
+        expect(fetchRedis as jest.Mock).toHaveBeenCalledWith('sismember','user:1966:friends', '1701');
+    });
+
+    test("fetcRedis' call to :incoming_friend_requests returns a falsy value", async()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
+        (fetchRedis as jest.Mock).mockImplementation(redisMock(false))
+        const expected: expectedResponse ={
+            text:'No Existing Friend Request',
+            status: 400
+        }
+
+        const request = requestify('1701');
+        const response = await POST(request);
+
+        assertResponse(response, expected);
+    });
+
+    test("fetcRedis' call to :incoming_friend_requests returns a truthy value, expect db.sadd to be called", async()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
+        (fetchRedis as jest.Mock).mockImplementation(redisMock())
+
+        const request = requestify('1701');
+        await POST(request);
+        expect(db.sadd).toHaveBeenCalledWith('user:1966:friends', '1701');
+        expect(db.sadd).toHaveBeenCalledWith('user:1701:friends', '1966');
+    });
+
+    test("fetcRedis' call to :incoming_friend_requests returns a truthy value, expect db.sadd to be called, different data", async()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'8569'}});
+        (fetchRedis as jest.Mock).mockImplementation(redisMock());
+
+        const request = requestify('666');
+        await POST(request);
+
+        expect(db.sadd).toHaveBeenCalledWith('user:8569:friends', '666');
+        expect(db.sadd).toHaveBeenCalledWith('user:666:friends', '8569');
+    });
+
+    test("expect the idtoAdd to be removed from the user's requests table", async()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'8569'}});
+        (fetchRedis as jest.Mock).mockImplementation(redisMock());
+
+        const request = requestify('666');
+        await POST(request);
+
+        expect(db.srem).toHaveBeenCalledWith('user:8569:incoming_friend_requests', '666');
+    });
+
+    test("expect the idtoAdd to be removed from the user's requests table", async()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'4567'}});
+        (fetchRedis as jest.Mock).mockImplementation(redisMock());
+
+        const request = requestify('7777');
+        await POST(request);
+
+        expect(db.srem).toHaveBeenCalledWith('user:4567:incoming_friend_requests', '7777');
+    });
 });
+
+function assertResponse( response: Response, expected: expectedResponse): void{
+    expect(response.status).toEqual(expected.status);
+    expect(response.body?.toString()).toEqual(expected.text);
+}
+
+function assertNotResponse( response: Response, expected: expectedResponse): void{
+    expect(response.status === expected.status && response.body?.toString()== expected.text);
+}
+
+function requestify(id: string | number): Request{
+    return new Request('/api/friends/accept', {
+        method: 'POST',
+        body: JSON.stringify({ id: id }),
+        headers: { 'Content-Type': 'application/json' }
+    });
+}
+
+function redisMock(isGreen: boolean = true){
+    return async ( command: string, query:string, opts:string)=>{
+        const arr = query.split(':');
+        const table_name = arr[arr.length-1];
+        switch(table_name){
+            case 'friends':
+                return false;
+            case 'incoming_friend_requests':
+                return isGreen ? 1 : 0;
+            default:
+                throw new Error('invalid table');
+        }
+    }
+}

--- a/__tests__/api/friends/accept/route.test.ts
+++ b/__tests__/api/friends/accept/route.test.ts
@@ -1,0 +1,18 @@
+import { POST } from "@/app/api/friends/accept/route";
+
+describe('/api/friends/accept', () => {
+    beforeEach(() => {
+        fetchMock.resetMocks(); // Ensure fresh mocks
+    });
+
+    test('POST should run without throwing', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+
+        const req = new Request('http://localhost/api/friends/accept', {
+            method: 'POST',
+            body: JSON.stringify({ someData: 'value' }),
+            headers: { 'Content-Type': 'application/json' }
+        });
+        await POST(req);
+    });
+});

--- a/__tests__/api/friends/accept/route.test.ts
+++ b/__tests__/api/friends/accept/route.test.ts
@@ -3,12 +3,12 @@ import myGetServerSession from "@/lib/myGetServerSession";
 import fetchRedis from "@/helpers/redis";
 import { db } from '@/lib/db';
 
-jest.mock("../../../../src/lib/myGetServerSession",()=>({
+jest.mock("@/lib/myGetServerSession",()=>({
     __esModule: true,
     default: jest.fn()
 }));
 
-jest.mock("../../../../src/lib/db",()=>({
+jest.mock("@/lib/db",()=>({
     __esModule: true,
     db: {
         sadd: jest.fn(),
@@ -16,7 +16,7 @@ jest.mock("../../../../src/lib/db",()=>({
     }
 }));
 
-jest.mock('../../../../src/helpers/redis')
+jest.mock('@/helpers/redis');
 
 interface expectedResponse {
     text: string,

--- a/__tests__/api/friends/accept/route.ts
+++ b/__tests__/api/friends/accept/route.ts
@@ -1,0 +1,3 @@
+describe('/api/friends/accept', () => {
+    test('first test',()=>{})
+});

--- a/__tests__/api/friends/accept/route.ts
+++ b/__tests__/api/friends/accept/route.ts
@@ -1,3 +1,0 @@
-describe('/api/friends/accept', () => {
-    test('first test',()=>{})
-});

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,8 @@ const customJestConfig = {
         '/node_modules/(?!next-auth|@next-auth/upstash-redis-adapter|uuid/.*)', // Ensure uuid and other modules are transformed
     ],
     moduleNameMapper: {
-        "^uuid$": "uuid"
+        "^uuid$": "uuid",
+        "^@/(.*)$": "<rootDir>/src/$1"
     },
 };
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const customJestConfig = {
     moduleDirectories: ['node_modules', '<rootDir>'],
     testEnvironment: 'jest-environment-jsdom',
     setupFiles: ['dotenv/config'],
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
     transform: {
         '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
     },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,2 @@
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.7.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "jest-fetch-mock": "^3.0.3",
         "lucide-react": "^0.447.0",
         "next": "14.2.13",
         "next-auth": "^4.24.8",
@@ -47,6 +48,9 @@
         "tailwindcss": "^3.4.13",
         "ts-jest": "^29.2.5",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": "22.9.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4793,6 +4797,57 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/cross-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7835,6 +7890,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -9819,6 +9884,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "jest-fetch-mock": "^3.0.3",
     "lucide-react": "^0.447.0",
     "next": "14.2.13",
     "next-auth": "^4.24.8",

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -1,0 +1,3 @@
+export async function  POST(req: Request):Promise<Response> {
+    throw new Error('Not implemented');
+}

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -1,3 +1,98 @@
-export async function  POST(req: Request):Promise<Response> {
-    throw new Error('Not implemented');
+import {z} from 'zod'
+import myGetServerSession from "@/lib/myGetServerSession";
+import fetchRedis from "@/helpers/redis";
+import {db} from "@/lib/db";
+
+export async function POST(request: Request):Promise<Response> {
+    const idToAdd = await getIdToAdd(request);
+    if (!idToAdd) {
+        return respond('Invalid Request', 422);
+    }
+
+    const  userId = await getUserId();
+    if (!userId) {
+        return respond('Unauthorized', 401);
+    }
+
+    const handler = new Handler(idToAdd as string, userId as string);
+    const areAlreadyFriends: boolean = await handler.areFriends();
+
+    if (areAlreadyFriends) {
+        return respond('Already Friends', 400);
+    }
+
+    const hasExistingFriendRequest = await handler.isInRequests();
+
+    if (!hasExistingFriendRequest) {
+        return respond('No Existing Friend Request', 400);
+    }
+
+    await handler.addtoFriendsTabeles();
+    await handler.removeRequestFromTable();
+    return new Response('OK');
+}
+
+class Handler{
+    idToAdd: string;
+    userId: string;
+
+    constructor(idToAdd: string, userId: string) {
+        this.idToAdd = idToAdd;
+        this.userId = userId;
+    }
+
+    async areFriends(): Promise<boolean>{
+        return fetchRedis('sismember', this.friendsTable(), this.idToAdd);
+    }
+
+    async isInRequests(): Promise<boolean>{
+       return  await fetchRedis('sismember', this.incomingRequestsQuery(), this.idToAdd) as number == 1;
+    }
+
+    async addtoFriendsTabeles():Promise<void>{
+        await this.addToFriendsTable(this.userId, this.idToAdd);
+        await this.addToFriendsTable(this.idToAdd, this.userId);
+    }
+
+    async removeRequestFromTable():Promise<void>{
+        await db.srem(this.incomingRequestsQuery(), this.idToAdd);
+    }
+
+    friendsTable(id: string = this.userId): string {
+        return this.userTable(id, 'friends');
+    }
+
+    incomingRequestsQuery(): string {
+        return this.userTable(this.userId, 'incoming_friend_requests');
+    }
+
+    async addToFriendsTable(userId: string = this.userId, idToAdd: string = this.idToAdd):Promise<void>{
+        await db.sadd(this.friendsTable(userId), idToAdd);
+    }
+
+    userTable(id: string, suffix: 'friends'| 'incoming_friend_requests'){
+        return `user:${id}:${suffix}`;
+    }
+}
+
+
+function respond(text: string, status: number): Response
+{
+    return  new Response(text, {status: status});
+}
+
+async function getUserId(): Promise<string | boolean>{
+    const session = await myGetServerSession();
+    return session?.user?.id || false;
+}
+
+async function getIdToAdd(request: Request):Promise<string | boolean> {
+    const body = await request.json();
+    try{
+        const { id: idToAdd } =  z.object({id: z.string()}).parse(body);
+        return idToAdd;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    }catch(error){
+        return false;
+    }
 }

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -43,11 +43,15 @@ class Handler{
     }
 
     async areFriends(): Promise<boolean>{
-        return fetchRedis('sismember', this.friendsTable(), this.idToAdd);
+        return this.fetchRedisTemplate(this.friendsTable());
     }
 
     async isInRequests(): Promise<boolean>{
-       return  await fetchRedis('sismember', this.incomingRequestsQuery(), this.idToAdd) as number == 1;
+        return this.fetchRedisTemplate(this.incomingRequestsQuery());
+    }
+
+    async fetchRedisTemplate(table: string): Promise<boolean>{
+        return  fetchRedis('sismember', table, this.idToAdd);
     }
 
     async addtoFriendsTabeles():Promise<void>{

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -5,6 +5,7 @@ import {db} from "@/lib/db";
 
 export async function POST(request: Request):Promise<Response> {
     const idToAdd = await getIdToAdd(request);
+
     if (!idToAdd) {
         return respond('Invalid Request', 422);
     }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -51,7 +51,6 @@ export class PostFriendsRouteHandler {
             console.error({error})
             return this.setAndReturn('Invalid request payload', 422)
         }
-        debugger;
         const userExists = await this.userExists(email.email)
         if (!userExists){
             return this.setAndReturn('This person does not exist.')


### PR DESCRIPTION
Build accept friend request endpoint.

If the request is valid, requester's id and user's id are added to each other's 'friends' tables, the requester's id is then removed from the user's "incoming friend requests" table.

Theendpoint returns a 4xx if one of the following
- the request is improperly validated
- the requester and user are already friends
- The user's ID can't be fetched from a valid session
- The requester's id is not in the user's existing friend requests

To make the testing process easier, installed jest-fetch-mock. This makes post a bit cleaner than the /add endpoint previously implemented
