### PR TITLE
Redirect logged in user to dashboard

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -47,34 +47,65 @@ describe('Middleware, functionality tests', () => {
     test('if is login page and user is authenticated, then redirect to dashboard',async()=>{
         const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://localhost:8000'};
         (getToken as jest.Mock).mockResolvedValue(true);
-        const nextSpy = jest.spyOn(NextResponse, 'redirect');
+        const mockURL = jest.spyOn(global, 'URL').mockImplementation((url) => {
+            return {
+                href: url,
+                toString: () => url,
+                // Add more properties as needed
+            };
+        });
+        const redirectSpy = jest.spyOn(NextResponse, 'redirect');
         await middleware(MockRequest as NextRequest);
-        expect(nextSpy).toHaveBeenCalledWith("http://localhost:8000/dashboard");
+        expect(mockURL).toHaveBeenCalledWith("/dashboard", "http://localhost:8000");
+        expect(redirectSpy).toHaveBeenCalled();
     });
 
     test('if is login page and user is authenticated, then redirect to dashboard, different data',async()=>{
         const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://liveendpoint.com'};
         (getToken as jest.Mock).mockResolvedValue(true);
-        const nextSpy = jest.spyOn(NextResponse, 'redirect');
+        const mockURL = jest.spyOn(global, 'URL').mockImplementation((url) => {
+            return {
+                href: url,
+                toString: () => url,
+                // Add more properties as needed
+            };
+        });
         await middleware(MockRequest as NextRequest);
-        expect(nextSpy).toHaveBeenCalledWith('http://liveendpoint.com/dashboard');
+        const redirectSpy = jest.spyOn(NextResponse, 'redirect');
+        expect(mockURL).toHaveBeenCalledWith("/dashboard", "http://liveendpoint.com");
+        expect(redirectSpy).toHaveBeenCalled();
     });
 
     test('if request is not authenticated and accessing a pathname that starts with "/dashboard", then redirect to login',
         async()=>{
             const MockRequest = {nextUrl:{pathname:'/dashboard-extra-path-values'}, url: 'http://liveendpoint.com'};
             (getToken as jest.Mock).mockResolvedValue(null);
-            const nextSpy = jest.spyOn(NextResponse, 'redirect');
+            const mockURL = jest.spyOn(global, 'URL').mockImplementation((url) => {
+                return {
+                    href: url,
+                    toString: () => url,
+                    // Add more properties as needed
+                };
+            });
+            const redirectSpy = jest.spyOn(NextResponse, 'redirect');
             await middleware(MockRequest as NextRequest);
-            expect(nextSpy).toHaveBeenCalledWith('http://liveendpoint.com/login');
+            expect(mockURL).toHaveBeenCalledWith("/login", "http://liveendpoint.com");
+            expect(redirectSpy).toHaveBeenCalled();
         });
 
     test('if request is for the home page, then redirect to dashboard',
         async()=>{
             const MockRequest = {nextUrl:{pathname:'/'}, url: 'http://liveendpoint.com'};
             (getToken as jest.Mock).mockResolvedValue(null);
-            const nextSpy = jest.spyOn(NextResponse, 'redirect');
+            const mockURL = jest.spyOn(global, 'URL').mockImplementation((url) => {
+                return {
+                    href: url,
+                    toString: () => url,
+                    // Add more properties as needed
+                };
+            });
+
             await middleware(MockRequest as NextRequest);
-            expect(nextSpy).toHaveBeenCalledWith('http://liveendpoint.com/dashboard');
+            expect(mockURL).toHaveBeenCalledWith("/dashboard", "http://liveendpoint.com");
         });
 });

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,80 @@
+import {config, middleware} from "@/middleware";
+import {getToken} from "next-auth/jwt";
+import {NextRequest, NextResponse} from "next/server";
+
+jest.mock("next-auth/jwt", () => ({
+    getToken: jest.fn(),
+}));
+
+describe('Middleware, config tests', () => {
+    test('config has a "matchers" key', () => {
+        expect(config).toEqual(
+            expect.objectContaining({matchers: expect.anything()}))
+    });
+    test('"matchers" includes /login, root and all dashboard pages', () => {
+        const expected  = ['login', '/', '/dashboard/:path*']
+        expect(config).toEqual(
+            expect.objectContaining({matchers:
+                    expect.arrayContaining(expected)}));
+    });
+});
+
+describe('Middleware, functionality tests', () => {
+    afterEach(()=>{
+        jest.resetAllMocks();
+    });
+    
+    test('if user is trying to access login page and is not authenticated, then middleware  directs them to /login',
+       async () => {
+            (getToken as jest.Mock).mockResolvedValue(null);
+            const nextSpy = jest.spyOn(NextResponse, 'next');
+            const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://localhost:8000'};
+            await middleware(MockRequest as NextRequest);
+            expect(nextSpy).toHaveBeenCalled();
+    });
+
+    test("if user is trying to access login page and is authenticated, then middleware doesn't call next",
+        async () => {
+            (getToken as jest.Mock).mockResolvedValue(true);
+            const nextSpy = jest.spyOn(NextResponse, 'next');
+            const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://localhost:8000'};
+
+            await middleware(MockRequest as NextRequest);
+
+            expect(nextSpy).not.toHaveBeenCalled();
+        });
+
+    test('if is login page and user is authenticated, then redirect to dashboard',async()=>{
+        const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://localhost:8000'};
+        (getToken as jest.Mock).mockResolvedValue(true);
+        const nextSpy = jest.spyOn(NextResponse, 'redirect');
+        await middleware(MockRequest as NextRequest);
+        expect(nextSpy).toHaveBeenCalledWith("http://localhost:8000/dashboard");
+    });
+
+    test('if is login page and user is authenticated, then redirect to dashboard, different data',async()=>{
+        const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://liveendpoint.com'};
+        (getToken as jest.Mock).mockResolvedValue(true);
+        const nextSpy = jest.spyOn(NextResponse, 'redirect');
+        await middleware(MockRequest as NextRequest);
+        expect(nextSpy).toHaveBeenCalledWith('http://liveendpoint.com/dashboard');
+    });
+
+    test('if request is not authenticated and accessing a pathname that starts with "/dashboard", then redirect to login',
+        async()=>{
+            const MockRequest = {nextUrl:{pathname:'/dashboard-extra-path-values'}, url: 'http://liveendpoint.com'};
+            (getToken as jest.Mock).mockResolvedValue(null);
+            const nextSpy = jest.spyOn(NextResponse, 'redirect');
+            await middleware(MockRequest as NextRequest);
+            expect(nextSpy).toHaveBeenCalledWith('http://liveendpoint.com/login');
+        });
+
+    test('if request is for the home page, then redirect to dashboard',
+        async()=>{
+            const MockRequest = {nextUrl:{pathname:'/'}, url: 'http://liveendpoint.com'};
+            (getToken as jest.Mock).mockResolvedValue(null);
+            const nextSpy = jest.spyOn(NextResponse, 'redirect');
+            await middleware(MockRequest as NextRequest);
+            expect(nextSpy).toHaveBeenCalledWith('http://liveendpoint.com/dashboard');
+        });
+});

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -20,6 +20,18 @@ describe('Middleware, config tests', () => {
 });
 
 describe('Middleware, functionality tests', () => {
+    let nextSpy: jest.SpyInstance;
+    let redirectSpy: jest.SpyInstance;
+    beforeEach(()=>{
+        jest.spyOn(global, 'URL').mockImplementation((url, baseUrl) => {
+            return {
+                url: url,
+                baseUrl: baseUrl
+            };
+        });
+        nextSpy = jest.spyOn(NextResponse, 'next');
+        redirectSpy = jest.spyOn(NextResponse, 'redirect');
+    })
     afterEach(()=>{
         jest.resetAllMocks();
     });
@@ -27,7 +39,6 @@ describe('Middleware, functionality tests', () => {
     test('if user is trying to access login page and is not authenticated, then middleware  directs them to /login',
        async () => {
             (getToken as jest.Mock).mockResolvedValue(null);
-            const nextSpy = jest.spyOn(NextResponse, 'next');
             const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://localhost:8000'};
             await middleware(MockRequest as NextRequest);
             expect(nextSpy).toHaveBeenCalled();
@@ -36,76 +47,38 @@ describe('Middleware, functionality tests', () => {
     test("if user is trying to access login page and is authenticated, then middleware doesn't call next",
         async () => {
             (getToken as jest.Mock).mockResolvedValue(true);
-            const nextSpy = jest.spyOn(NextResponse, 'next');
             const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://localhost:8000'};
-
             await middleware(MockRequest as NextRequest);
-
             expect(nextSpy).not.toHaveBeenCalled();
         });
 
     test('if is login page and user is authenticated, then redirect to dashboard',async()=>{
         const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://localhost:8000'};
         (getToken as jest.Mock).mockResolvedValue(true);
-        const mockURL = jest.spyOn(global, 'URL').mockImplementation((url) => {
-            return {
-                href: url,
-                toString: () => url,
-                // Add more properties as needed
-            };
-        });
-        const redirectSpy = jest.spyOn(NextResponse, 'redirect');
         await middleware(MockRequest as NextRequest);
-        expect(mockURL).toHaveBeenCalledWith("/dashboard", "http://localhost:8000");
-        expect(redirectSpy).toHaveBeenCalled();
+        expect(redirectSpy).toHaveBeenCalledWith({url: '/dashboard', baseUrl: "http://localhost:8000"});
     });
 
     test('if is login page and user is authenticated, then redirect to dashboard, different data',async()=>{
         const MockRequest = {nextUrl:{pathname:'/login'}, url: 'http://liveendpoint.com'};
         (getToken as jest.Mock).mockResolvedValue(true);
-        const mockURL = jest.spyOn(global, 'URL').mockImplementation((url) => {
-            return {
-                href: url,
-                toString: () => url,
-                // Add more properties as needed
-            };
-        });
         await middleware(MockRequest as NextRequest);
-        const redirectSpy = jest.spyOn(NextResponse, 'redirect');
-        expect(mockURL).toHaveBeenCalledWith("/dashboard", "http://liveendpoint.com");
-        expect(redirectSpy).toHaveBeenCalled();
+        expect(redirectSpy).toHaveBeenCalledWith({url: '/dashboard', baseUrl: "http://liveendpoint.com"});
     });
 
     test('if request is not authenticated and accessing a pathname that starts with "/dashboard", then redirect to login',
         async()=>{
             const MockRequest = {nextUrl:{pathname:'/dashboard-extra-path-values'}, url: 'http://liveendpoint.com'};
             (getToken as jest.Mock).mockResolvedValue(null);
-            const mockURL = jest.spyOn(global, 'URL').mockImplementation((url) => {
-                return {
-                    href: url,
-                    toString: () => url,
-                    // Add more properties as needed
-                };
-            });
-            const redirectSpy = jest.spyOn(NextResponse, 'redirect');
             await middleware(MockRequest as NextRequest);
-            expect(mockURL).toHaveBeenCalledWith("/login", "http://liveendpoint.com");
-            expect(redirectSpy).toHaveBeenCalled();
+            expect(redirectSpy).toHaveBeenCalledWith({url: '/login', baseUrl: "http://liveendpoint.com"});
         });
 
     test('if request is for the home page, then redirect to dashboard',
         async()=>{
             const MockRequest = {nextUrl:{pathname:'/'}, url: 'http://liveendpoint.com'};
             (getToken as jest.Mock).mockResolvedValue(null);
-            const mockURL = jest.spyOn(global, 'URL').mockImplementation((url) => {
-                return {
-                    href: url,
-                    toString: () => url,
-                    // Add more properties as needed
-                };
-            });
-
             await middleware(MockRequest as NextRequest);
-            expect(mockURL).toHaveBeenCalledWith("/dashboard", "http://liveendpoint.com");
+            expect(redirectSpy).toHaveBeenCalledWith({url: '/dashboard', baseUrl: "http://liveendpoint.com"});
         });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,69 @@
+import {NextRequest, NextResponse} from "next/server";
+import {getToken, JWT} from "next-auth/jwt";
+import {withAuth} from "next-auth/middleware";
+
+export const config = {
+    matchers:  ['login', '/', '/dashboard/:path*']
+}
+
+export const middleware = async (req: NextRequest)=>{
+    const JWT = await getToken({req});
+    const handler = new Handler(req, JWT);
+
+    if (handler.isLogin()){
+        if (handler.isAuthenticated()){
+            return handler.redirectToDashboard()
+        }
+        return handler.next();
+    }
+
+    if (handler.isAccessingSensitiveRoute() && !handler.isAuthenticated()){
+        return handler.redirectToLogin();
+    }
+
+    if (handler.isPointingToHome()){
+        return handler.redirectToDashboard();
+    }
+}
+
+class Handler {
+    _jwt: JWT | null;
+    _targetPath: string;
+    _url: string;
+
+    constructor(request: NextRequest, jwt: JWT | null) {
+        this._targetPath = request.nextUrl.pathname;
+        this._url = request.url;
+        this._jwt = jwt;
+    }
+
+    isAuthenticated(): boolean{
+        return !! this._jwt;
+    }
+
+    isLogin(): boolean{
+        return this._targetPath.startsWith('/login');
+    }
+
+    next(){
+        return NextResponse.next()
+    }
+
+    redirectToDashboard(){
+        return NextResponse.redirect(`${this._url}/dashboard`);
+    }
+
+    redirectToLogin(){
+        return NextResponse.redirect(`${this._url}/login`);
+    }
+
+    isAccessingSensitiveRoute(){
+        return this._targetPath.startsWith('/dashboard');
+    }
+
+    isPointingToHome(){
+        return this._targetPath === '/';
+    }
+}
+
+export default withAuth(middleware);


### PR DESCRIPTION
Only non-logged in users should be able to get to the /login page.
Non-logged-in users shoudn't access /dashboard or it's subpages.
Home redirects to dashboard if logged in.