### PR TITLE
Async chat ii

### DIFF
--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/helpers.test.ts
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/helpers.test.ts
@@ -28,13 +28,13 @@ describe('test getChatMessage for 404 cases',()=>{
     test('if fetchChatById throws, notFound is called', async () => {
         jest.spyOn(helpers, 'fetchChatById').mockRejectedValue('Bad')
 
-        await helpers.getChatMessage("chat:userOne-userTwo:message");
+        await helpers.getChatMessages("chat:userOne-userTwo:message");
 
         expect(notFound).toHaveBeenCalled();
     });
 
     test("if fetchRedis doesn't throw, notFound isn't called", async () => {
-        await helpers.getChatMessage("chat:userOne-userTwo:message");
+        await helpers.getChatMessages("chat:userOne-userTwo:message");
 
         expect(notFound).not.toHaveBeenCalled();
     });
@@ -57,7 +57,7 @@ describe('confirm getChatMessage is called with the output of fetchChatById', ()
         jest.spyOn(helpers, "fetchChatById").mockResolvedValue(["{\"id\": \"1701\", \"senderId\": \"bob\", \"text\":\"Hello world. My name's Gypsy, what's yours?\", \"timestamp\":1729437427}"]);
         const validatorSpy = jest.spyOn(messageArraySchema, 'parse');
 
-        await helpers.getChatMessage("chat:userOne-userTwo:message");
+        await helpers.getChatMessages("chat:userOne-userTwo:message");
 
         expect(validatorSpy).toHaveBeenCalledWith([{id: '1701', senderId: 'bob', text:"Hello world. My name's Gypsy, what's yours?", timestamp:1729437427}]);
     });
@@ -66,7 +66,7 @@ describe('confirm getChatMessage is called with the output of fetchChatById', ()
         jest.spyOn(helpers, "fetchChatById").mockResolvedValue(["{\"id\": \"1701\", \"senderId\": \"bob\", \"text\":\"Captain, you're being hailed\", \"timestamp\":1729437427}"]);
         const validatorSpy = jest.spyOn(messageArraySchema, 'parse');
 
-        await helpers.getChatMessage("chat:userOne-userTwo:message");
+        await helpers.getChatMessages("chat:userOne-userTwo:message");
 
         expect(validatorSpy).toHaveBeenCalledWith([{id: '1701', senderId: 'bob', text:"Captain, you're being hailed", timestamp:1729437427}]);
     });
@@ -95,7 +95,7 @@ describe('fetchByChatId returns an array with the most recent timestamp first,so
            return data as { id: string; senderId: string; recieverId: string; text: string; timestamp: number }[];
         });
 
-       const result =  await helpers.getChatMessage("chat:1071-1701:message");
+       const result =  await helpers.getChatMessages("chat:1071-1701:message");
 
        expect(result).toEqual([ {id: '1071', senderId: 'alice',recieverId:'1701', text:"Hi bob", timestamp:1729437427},{id: '1701', senderId: 'bob',recieverId: '1071', text:"Hi Alice, what's up", timestamp:1729533949}])
     });
@@ -111,7 +111,7 @@ describe('fetchByChatId returns an array with the most recent timestamp first,so
             return data as { id: string; senderId: string; recieverId: string; text: string; timestamp: number }[];
         });
 
-        const result =  await helpers.getChatMessage("chat:1071-1701:message");
+        const result =  await helpers.getChatMessages("chat:1071-1701:message");
 
         expect(result).toEqual([
             {id:'1071', senderId: 'alice', recieverId:"1701", text:"Hey, it's 1970", timestamp: 0},

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -153,6 +153,14 @@ describe('Chat page makes expected calls', ()=>{
 
         expect(db.get as jest.Mock).toHaveBeenCalledWith('user:kirk');
     })
+
+    test('db is called with correct params for user',async ()=>{
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'mindy'}});
+
+        render(await Page({params:{chatId: 'mindy--mork'}}));
+
+        expect(db.get as jest.Mock).toHaveBeenCalledWith('user:mork');
+    })
 })
 
 

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -120,4 +120,12 @@ describe('Chat page makes expected calls', ()=>{
 
         expect(db.get as jest.Mock).toHaveBeenCalledWith('user:spock');
     })
+
+    test('db is called with correct params for user',async ()=>{
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'spock'}});
+
+        render(await Page({params:{chatId: 'kirk--spock'}}));
+
+        expect(db.get as jest.Mock).toHaveBeenCalledWith('user:kirk');
+    })
 })

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -172,6 +172,19 @@ describe('ChatPage renders with expected content', () => {
         const email = getByText("spock@vulcanscience.edu")
         expect(email).toBeInTheDocument();
     })
+
+    test("document should display chat partner's email",async ()=>{
+        (db.get as jest.Mock).mockResolvedValue({
+            name: "spock",
+            email: "scooby@doo.com",
+            image: "/stub",
+            id: "userid2",
+        });
+
+        const {getByText} = render(await Page({params:{chatId: 'userid1--userid2'}}));
+        const email = getByText("scooby@doo.com")
+        expect(email).toBeInTheDocument();
+    })
 });
 
 describe('Chat page makes expected calls', ()=>{

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -228,6 +228,14 @@ describe('Chat page makes expected calls', ()=>{
 
         expect(db.get as jest.Mock).toHaveBeenCalledWith('user:mork');
     })
+
+    test('Messages is called with ',async ()=>{
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'mindy'}});
+
+        render(await Page({params:{chatId: 'mindy--mork'}}));
+
+        expect(db.get as jest.Mock).toHaveBeenCalledWith('user:mork');
+    })
 })
 
 

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -67,7 +67,7 @@ describe('ChatPage renders with expected content', () => {
         expect(image).toBeInTheDocument();
     });
 
-    test("chat image should be sourced from chat partner's name",async ()=>{
+    test("chat image should be sourced from chat partner's ID",async ()=>{
         const url = "/uglyImage";
         (db.get as jest.Mock).mockResolvedValue({
             name: "stub",
@@ -96,6 +96,20 @@ describe('ChatPage renders with expected content', () => {
         expect(element).toHaveAttribute('src',
             expect.stringContaining(encodeUrl(url)));
     });
+
+    test("chat image should have alt text for partner's name", async ()=>{
+        (db.get as jest.Mock).mockResolvedValue({
+            name: "fooey",
+            email: "stub",
+            image: "/stub",
+            id: "userid2",
+        });
+
+        const {getByRole} = render(await Page({params:{chatId: 'userid1--userid2'}}))
+        const element = getByRole('img');
+        expect(element).toHaveAttribute('alt',
+            expect.stringContaining('fooey'));
+    })
 });
 
 describe('Chat page makes expected calls', ()=>{

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import {render} from '@testing-library/react'
+import { render} from '@testing-library/react';
 import Page from '@/app/(dashboard)/dashboard/chat/[chatId]/page'
 
 import myGetServerSession from "@/lib/myGetServerSession";
@@ -184,6 +184,12 @@ describe('ChatPage renders with expected content', () => {
         const {getByText} = render(await Page({params:{chatId: 'userid1--userid2'}}));
         const email = getByText("scooby@doo.com")
         expect(email).toBeInTheDocument();
+    })
+
+    test("document should contain a messages component",async ()=>{
+        const {queryByLabelText} = render(await Page({params:{chatId: 'userid1--userid2'}}));
+        const messages = queryByLabelText('messages')
+        expect(messages).toBeInTheDocument();
     })
 });
 

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -51,5 +51,5 @@ describe('ChatPage renders with expected content', () => {
     test('chat page should render with an image',async ()=>{
         const {getByRole} = render(await Page({params:{chatId: 'userid1--userid2'}}));
         expect(getByRole('img')).toBeInTheDocument();
-    })
+    });
 });

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -125,11 +125,25 @@ describe('ChatPage renders with expected content', () => {
             expect.stringContaining('alice'));
     })
 
-    test('user is valide, but not for the chat', async ()=>{
+    test('user is valid, but not for the chat', async ()=>{
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'userid1'}});
         render(await Page({params:{chatId: 'userid2--userid3'}}));
 
         expect(notFound).toHaveBeenCalled();
+    })
+
+    test("document should display chat partner's name", async ()=>{
+        (db.get as jest.Mock).mockResolvedValue({
+            name: "alice",
+            email: "stub",
+            image: "/stub",
+            id: "userid2",
+        });
+
+        const {getByText} = render(await Page({params:{chatId: 'useri12--userid2'}}));
+        const name = getByText('alice')
+
+        expect(name).toBeInTheDocument();
     })
 });
 

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -63,7 +63,7 @@ describe('ChatPage renders with expected content', () => {
 
     test('chat page should render with an image',async ()=>{
         const {getByRole} = render(await Page({params:{chatId: 'userid1--userid2'}}));
-        const image = getByRole('img', { name: /partner name/i });
+        const image = getByRole('img');
         expect(image).toBeInTheDocument();
     });
 

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -68,7 +68,7 @@ describe('ChatPage renders with expected content', () => {
     });
 
     test("chat image should be sourced from chat partner's name",async ()=>{
-        const url = "https://i.kym-cdn.com/entries/icons/original/000/023/846/lisa.jpg";
+        const url = "/uglyImage";
         (db.get as jest.Mock).mockResolvedValue({
             name: "stub",
             email: "stub",
@@ -83,7 +83,7 @@ describe('ChatPage renders with expected content', () => {
     });
 
     test("chat image should be sourced from chat partner's name, different data",async ()=>{
-        const url = "https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg";
+        const url = "/fancyImage";
         (db.get as jest.Mock).mockResolvedValue({
             name: "stub",
             email: "stub",

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -145,6 +145,20 @@ describe('ChatPage renders with expected content', () => {
 
         expect(name).toBeInTheDocument();
     })
+
+    test("document should display chat partner's name", async ()=>{
+        (db.get as jest.Mock).mockResolvedValue({
+            name: "spock",
+            email: "stub",
+            image: "/stub",
+            id: "userid2",
+        });
+
+        const {getByText} = render(await Page({params:{chatId: 'useri12--userid2'}}));
+        const name = getByText('spock')
+
+        expect(name).toBeInTheDocument();
+    })
 });
 
 describe('Chat page makes expected calls', ()=>{

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -154,10 +154,23 @@ describe('ChatPage renders with expected content', () => {
             id: "userid2",
         });
 
-        const {getByText} = render(await Page({params:{chatId: 'useri12--userid2'}}));
+        const {getByText} = render(await Page({params:{chatId: 'userid21-userid2'}}));
         const name = getByText('spock')
 
         expect(name).toBeInTheDocument();
+    })
+
+    test("document should display chat partner's email",async ()=>{
+        (db.get as jest.Mock).mockResolvedValue({
+            name: "spock",
+            email: "spock@vulcanscience.edu",
+            image: "/stub",
+            id: "userid2",
+        });
+
+        const {getByText} = render(await Page({params:{chatId: 'userid1--userid2'}}));
+        const email = getByText("spock@vulcanscience.edu")
+        expect(email).toBeInTheDocument();
     })
 });
 

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -110,6 +110,20 @@ describe('ChatPage renders with expected content', () => {
         expect(element).toHaveAttribute('alt',
             expect.stringContaining('fooey'));
     })
+
+    test("chat image should have alt text for partner's name", async ()=>{
+        (db.get as jest.Mock).mockResolvedValue({
+            name: "alice",
+            email: "stub",
+            image: "/stub",
+            id: "userid2",
+        });
+
+        const {getByRole} = render(await Page({params:{chatId: 'userid1--userid2'}}))
+        const element = getByRole('img');
+        expect(element).toHaveAttribute('alt',
+            expect.stringContaining('alice'));
+    })
 });
 
 describe('Chat page makes expected calls', ()=>{

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -124,6 +124,13 @@ describe('ChatPage renders with expected content', () => {
         expect(element).toHaveAttribute('alt',
             expect.stringContaining('alice'));
     })
+
+    test('user is valide, but not for the chat', async ()=>{
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'userid1'}});
+        render(await Page({params:{chatId: 'userid2--userid3'}}));
+
+        expect(notFound).toHaveBeenCalled();
+    })
 });
 
 describe('Chat page makes expected calls', ()=>{

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -100,3 +100,24 @@ describe('ChatPage renders with expected content', () => {
             expect.stringContaining("https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"));
     });
 });
+
+describe('Chat page makes expected calls', ()=>{
+    beforeEach(()=>{
+        jest.resetAllMocks();
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'stub'}});
+        (db.get as jest.Mock).mockResolvedValue({
+            name: "stub",
+            email: "stub",
+            image: "stub",
+            id: "stub",
+        });
+    });
+
+    test('db is called with correct params for user',async ()=>{
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'kirk'}});
+
+        render(await Page({params:{chatId: 'kirk--spock'}}));
+
+        expect(db.get as jest.Mock).toHaveBeenCalledWith('user:spock');
+    })
+})

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -14,7 +14,7 @@ jest.mock("next/navigation", () => ({
     notFound: jest.fn(),
 }));
 
-describe('ChatPage tests', () => {
+describe('ChatPage renders with expected content', () => {
     beforeEach(()=>{
         jest.resetAllMocks();
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'stub'}});
@@ -48,7 +48,8 @@ describe('ChatPage tests', () => {
         expect(notFound).toHaveBeenCalled();
     });
 
-    test('if Page is called, the helper function "getChatMessages is called with the the chatId', async ()=>{
-      //TBD
-    });
+    test('chat page should render with an image',async ()=>{
+        const {getByRole} = render(await Page({params:{chatId: 'userid1--userid2'}}));
+        expect(getByRole('img')).toBeInTheDocument();
+    })
 });

--- a/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
+++ b/__tests__/app/(dashboard)/dashboard/chat/[chatId]/page.test.tsx
@@ -84,6 +84,19 @@ describe('ChatPage renders with expected content', () => {
         const element = getByRole('img');
         expect(element).toHaveAttribute('src',
             expect.stringContaining("https://i.kym-cdn.com/entries/icons/original/000/023/846/lisa.jpg"));
+    });
 
+    test("chat image should be sourced from chat partner's name, different data",async ()=>{
+        (db.get as jest.Mock).mockResolvedValue({
+            name: "stub",
+            email: "stub",
+            image: "https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg",
+            id: "stub",
+        });
+
+        const {getByRole} = render(await Page({params:{chatId: 'userid1--userid2'}}));
+        const element = getByRole('img');
+        expect(element).toHaveAttribute('src',
+            expect.stringContaining("https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"));
     });
 });

--- a/__tests__/components/ChatInput/ChatInput.test.tsx
+++ b/__tests__/components/ChatInput/ChatInput.test.tsx
@@ -1,30 +1,173 @@
 import '@testing-library/jest-dom';
-import {render,} from '@testing-library/react';
+import {fireEvent, render,} from '@testing-library/react';
 import ChatInput from '@/components/ChatInput/ChatInput';
+import {useState} from "react";
+import Helpers from "@/components/ChatInput/helpers";
+
+jest.mock('react', ()=>({
+    ...jest.requireActual('react'),
+    useState: jest.fn()
+}));
 
 describe('ChatInput Component displays', () => {
+    let partner: User
+    beforeEach(()=>{
+        jest.resetAllMocks();
+        let count = 0;
+        (useState as jest.Mock).mockImplementation(()=>{
+            if (count == 0){
+                count ++;
+                return ['', jest.fn()]
+            }
+            return [false, jest.fn()];
+        });
+        partner  = {
+            name: 'stub',
+            email: 'stub',
+            image: 'stub',
+            id: 'stub'
+        }
+    });
+
     test('renders the TextareaAutosize component', () => {
-        const {getByLabelText} = render(<ChatInput />);
+        const {getByLabelText} = render(<ChatInput chatPartner={partner} />);
         expect(getByLabelText('autosize field')).toBeInTheDocument();
     });
 
     test('TextareaAutosize component has the correct aria-label', () => {
-        const {getByLabelText} = render(<ChatInput />);
+        const {getByLabelText} = render(<ChatInput chatPartner={partner} />);
         const textArea = getByLabelText('autosize field');
         expect(textArea).toBeInTheDocument();
         expect(textArea).toHaveAttribute('aria-label', 'autosize field');
     });
 
-    test('TextareaAutosize component generates with the correct placeholder text', () => {
-        const {getByLabelText} = render(<ChatInput />);
+    test('TextareaAutosize component generates with the placeholder text', () => {
+        let count = 0;
+        (useState as jest.Mock).mockImplementation(()=>{
+            if (count == 0){
+                count ++;
+                return ['Hello Batman', jest.fn()]
+            }
+            return [false, jest.fn()];
+        });
+
+        const {getByLabelText} = render(<ChatInput chatPartner={partner} />);
         const textArea = getByLabelText('autosize field');
-        expect(textArea).toBeInTheDocument();
-        expect(textArea).toHaveAttribute('placeholder', 'Message Batman');
+        expect(textArea).toHaveValue('Hello Batman');
     });
-    test('TextareaAutosize component generates with the correct placeholder text, Different Data', () => {
-        const {getByLabelText} = render(<ChatInput />);
+
+    test('TextareaAutosize component generates with the correct text, Different Data', () => {
+        let count = 0;
+        (useState as jest.Mock).mockImplementation(()=>{
+            if (count == 0){
+                count ++;
+                return ['Hello Alfred', jest.fn()]
+            }
+            return [false, jest.fn()];
+        });
+
+        const {getByLabelText} = render(<ChatInput chatPartner={partner} />);
         const textArea = getByLabelText('autosize field');
-        expect(textArea).toBeInTheDocument();
-        expect(textArea).toHaveAttribute('placeholder', 'Message Alfred');
+        expect(textArea).toHaveValue('Hello Alfred');
     });
+
+    test('TextareaAutosize component generates with the correct number of rows', () => {
+        const {getByLabelText} = render(<ChatInput chatPartner={partner} />);
+        const textArea = getByLabelText('autosize field');
+        expect(textArea).toHaveAttribute('rows', '1');
+    });
+
+    test('Placeholder text should include the name of your chat partner', () => {
+         partner= {
+            name: 'Alvin',
+            email: 'alvin@chipmunk.com',
+            image: 'stub',
+            id: 'stub'
+        }
+
+        const {getByLabelText} = render(<ChatInput chatPartner={partner}/>);
+        const textArea = getByLabelText('autosize field');
+
+        expect(textArea).toHaveAttribute('placeholder', 'Send Alvin a message');
+    });
+
+    test('Placeholder text should include the name of your chat partner, different data', () => {
+         partner =  {
+            name: 'Simon',
+            email: 'simon@chipmunk.com',
+            image: 'stub',
+            id: 'stub'
+        }
+
+        const {getByLabelText} = render(<ChatInput chatPartner={partner} />);
+        const textArea = getByLabelText('autosize field');
+
+        expect(textArea).toHaveAttribute('placeholder', 'Send Simon a message');
+    });
+
+    test('Component should display a Button', ()=>{
+        const {getByRole} = render(<ChatInput chatPartner={partner} />);
+        const buttonElement = getByRole('button', { name: /Send/i });
+        expect(buttonElement).toBeInTheDocument();
+    })
 });
+
+describe('ChatInput inner logic', ()=>{
+    let partner: User;
+    beforeEach(()=>{
+        jest.resetAllMocks();
+        (useState as jest.Mock).mockImplementation(()=>{ return ['', jest.fn()]});
+        partner  = {
+            name: 'stub',
+            email: 'stub',
+            image: 'stub',
+            id: 'stub'
+        }
+    });
+
+    test('input is set with text from change event, different data', () => {
+        const setInputMock = jest.fn();
+        (useState as jest.Mock).mockImplementation(()=>{ return ['', setInputMock]});
+
+        const {getByLabelText} = render(<ChatInput chatPartner={partner} />);
+        const textArea = getByLabelText('autosize field');
+        fireEvent.change(textArea, { target: { value: 'Bonjour' } });
+
+        expect(setInputMock).toHaveBeenCalledWith('Bonjour');
+    });
+
+    test('input is set with text from change event', () => {
+        const setInputMock = jest.fn();
+        (useState as jest.Mock).mockImplementation(()=>{ return ['', setInputMock]});
+
+        const {getByLabelText} = render(<ChatInput chatPartner={partner} />);
+        const textArea = getByLabelText('autosize field');
+        fireEvent.change(textArea, { target: { value: 'Hello Clarice' } });
+
+        expect(setInputMock).toHaveBeenCalledWith('Hello Clarice');
+    });
+
+    test('If change does not occur, do not change state', () => {
+        const setInputMock = jest.fn();
+        (useState as jest.Mock).mockImplementation(()=>{ return ['', setInputMock]});
+
+        render(<ChatInput chatPartner={partner} />);
+
+        expect(setInputMock).not.toHaveBeenCalled();
+    });
+
+    test('If button is clicked, call helpers.SendMessage', () => {
+        const SendMessageSpy = jest.spyOn(Helpers.prototype, 'SendMessage')
+        const {getByRole} = render(<ChatInput chatPartner={partner} />);
+        const buttonElement = getByRole('button', { name: /Send/i });
+        fireEvent.click(buttonElement);
+        expect(SendMessageSpy).toHaveBeenCalled();
+    })
+
+    test('If button is  not clicked,  do not call helpers.SendMessage', () => {
+        const SendMessageSpy = jest.spyOn(Helpers.prototype, 'SendMessage')
+        render(<ChatInput chatPartner={partner} />);
+
+        expect(SendMessageSpy).not.toHaveBeenCalled();
+    })
+})

--- a/__tests__/components/ChatInput/ChatInput.test.tsx
+++ b/__tests__/components/ChatInput/ChatInput.test.tsx
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom';
+import {render,} from '@testing-library/react';
+import ChatInput from '@/components/ChatInput/ChatInput';
+
+describe('ChatInput Component displays', () => {
+    test('renders the TextareaAutosize component', () => {
+        const {getByLabelText} = render(<ChatInput />);
+        expect(getByLabelText('autosize field')).toBeInTheDocument();
+    });
+
+    test('TextareaAutosize component has the correct aria-label', () => {
+        const {getByLabelText} = render(<ChatInput />);
+        const textArea = getByLabelText('autosize field');
+        expect(textArea).toBeInTheDocument();
+        expect(textArea).toHaveAttribute('aria-label', 'autosize field');
+    });
+
+    test('TextareaAutosize component generates with the correct placeholder text', () => {
+        const {getByLabelText} = render(<ChatInput />);
+        const textArea = getByLabelText('autosize field');
+        expect(textArea).toBeInTheDocument();
+        expect(textArea).toHaveAttribute('placeholder', 'Message Batman');
+    });
+    test('TextareaAutosize component generates with the correct placeholder text, Different Data', () => {
+        const {getByLabelText} = render(<ChatInput />);
+        const textArea = getByLabelText('autosize field');
+        expect(textArea).toBeInTheDocument();
+        expect(textArea).toHaveAttribute('placeholder', 'Message Alfred');
+    });
+});

--- a/__tests__/components/ChatInput/helpers.test.ts
+++ b/__tests__/components/ChatInput/helpers.test.ts
@@ -1,0 +1,31 @@
+import {sendMessage} from "@/components/ChatInput/helpers";
+import React from "react";
+
+describe('SendMessage tests', () => {
+    test('key is Enter, prevent default is called',()=>{
+        const event = keyEvent('Enter')
+        sendMessage(event)
+        expect(event.preventDefault).toHaveBeenCalled()
+
+    })
+
+    test('key is not Enter, prevent default not called',()=>{
+        const event = keyEvent('Tab')
+        sendMessage(event)
+        expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+
+    test('key is Enter + shift, prevent default is not called',()=>{
+        const event = keyEvent('Enter')
+        event.shiftKey = true
+        sendMessage(event)
+        expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+})
+
+const keyEvent=(key: string) =>{
+    return {
+        key: key,
+        preventDefault: jest.fn()
+    } as unknown as React.KeyboardEvent<HTMLTextAreaElement>
+}

--- a/__tests__/components/ChatInput/helpers.test.ts
+++ b/__tests__/components/ChatInput/helpers.test.ts
@@ -1,26 +1,181 @@
-import {sendMessage} from "@/components/ChatInput/helpers";
+import Helpers from "@/components/ChatInput/helpers";
 import React from "react";
+import axios from "axios";
 
-describe('SendMessage tests', () => {
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('HandleKeystroke tests', () => {
+    let helpers: Helpers
+    let sendMessageSpy: jest.SpyInstance
+    beforeEach(() => {
+        jest.resetAllMocks()
+        const s = {
+            setInput: jest.fn(),
+            setIsLoading: jest.fn(),
+            reference: jest.fn()
+        }
+        helpers = new Helpers(s, 'stub')
+        sendMessageSpy = jest.spyOn(helpers, 'SendMessage')
+        mockedAxios.post.mockImplementation(jest.fn());
+    })
     test('key is Enter, prevent default is called',()=>{
         const event = keyEvent('Enter')
-        sendMessage(event)
+        helpers.HandleKeystroke(event, 'stub')
         expect(event.preventDefault).toHaveBeenCalled()
+    })
 
+    test('key is Enter, sendMessage is called',()=>{
+        const event = keyEvent('Enter')
+        helpers.HandleKeystroke(event, 'stub')
+        expect(sendMessageSpy).toHaveBeenCalled()
     })
 
     test('key is not Enter, prevent default not called',()=>{
         const event = keyEvent('Tab')
-        sendMessage(event)
+        helpers.HandleKeystroke(event, 'stub')
         expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+
+    test('key is not Enter, SendMessage is not called',()=>{
+        const event = keyEvent('Tab')
+        helpers.HandleKeystroke(event, 'stub')
+        expect(sendMessageSpy).not.toHaveBeenCalled()
     })
 
     test('key is Enter + shift, prevent default is not called',()=>{
         const event = keyEvent('Enter')
         event.shiftKey = true
-        sendMessage(event)
+        helpers.HandleKeystroke(event, 'stub')
         expect(event.preventDefault).not.toHaveBeenCalled()
     })
+
+    test('key is Enter + shift, SendMessage is not called',()=>{
+        const event = keyEvent('Enter')
+        event.shiftKey = true
+        helpers.HandleKeystroke(event, 'stub')
+        expect(sendMessageSpy).not.toHaveBeenCalled()
+    })
+})
+
+describe('SendMessage tests', () => {
+    let helpers: Helpers
+    let setIsLoading:  React.Dispatch<React.SetStateAction<boolean>>
+
+    beforeEach(()=>{
+        jest.resetAllMocks();
+        setIsLoading = jest.fn()
+        const s = {
+            setInput: jest.fn(),
+            setIsLoading,
+            reference: jest.fn()
+        }
+        helpers = new Helpers(s, 'stub')
+        mockedAxios.post.mockImplementation(jest.fn());
+    })
+
+    test('setter should be called with true', async ()=>{
+        await helpers.SendMessage('stub')
+        expect(setIsLoading).toHaveBeenCalledWith(true)
+    })
+
+    test('axios post should be called with endpoint /api/message/send', async ()=>{
+        await helpers.SendMessage('stub')
+        expect(mockedAxios.post).toHaveBeenCalledWith('/api/message/send', expect.anything());
+    })
+
+    test('axios post should be called with payload {text: input}', async ()=>{
+        const input = 'Never give up. Never surrender'
+        await helpers.SendMessage(input)
+        expect(mockedAxios.post).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({text:input}));
+    })
+
+    test('axios post should be called with payload {text: input}, different data', async ()=>{
+        const input = 'I am and always will be your friend'
+        await helpers.SendMessage(input)
+        expect(mockedAxios.post).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({text:input}));
+    })
+
+    test('axios post should be called with chatId: juliet--romeo', async ()=>{
+        const input = 'I am and always will be your friend'
+        const chatId = 'juliet--romeo'
+        const s = {setInput: jest.fn(), setIsLoading: jest.fn()}
+        helpers = new Helpers(s, chatId)
+        await helpers.SendMessage(input)
+        expect(mockedAxios.post).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({chatId: chatId}));
+    })
+
+    test('axios post should be called with chatId: gorignack--jason', async ()=>{
+        const input = 'I am and always will be your friend'
+        const chatId = 'gorignack--jason'
+        const s = {setInput: jest.fn(), setIsLoading: jest.fn()}
+        helpers = new Helpers(s, chatId)
+        await helpers.SendMessage(input)
+        expect(mockedAxios.post).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({chatId: chatId}));
+    })
+
+    test ('second call to setIsLoading should be  "false"', async ()=>{
+        await helpers.SendMessage('stub')
+        expect(setIsLoading).toHaveBeenCalledWith(false)
+    })
+
+    test ('even if post throws, setIsLoading should still call  "false"', async ()=>{
+        mockedAxios.post.mockImplementation(()=>{ throw new Error('error') });
+        await helpers.SendMessage('stub')
+        expect(setIsLoading).toHaveBeenCalledWith(false)
+    })
+
+    test ('when axios post completes, clear the field', async ()=>{
+        const clearInputSpy = jest.spyOn(helpers, 'clearInput')
+        await helpers.SendMessage('stub')
+        expect(clearInputSpy).toHaveBeenCalled()
+    })
+
+    test ('when axios post completes, setFocus', async ()=>{
+        const setFocus = jest.spyOn(helpers, 'setFocus')
+        await helpers.SendMessage('stub')
+        expect(setFocus).toHaveBeenCalled()
+    })
+})
+
+describe('clearInput tests', ()=>{
+    let helpers: Helpers
+    let setInputSpy: jest.Mock
+
+    beforeEach(() => {
+        jest.resetAllMocks()
+        setInputSpy = jest.fn()
+        const s = {
+            setInput: setInputSpy,
+            setIsLoading: jest.fn(),
+            reference: jest.fn()
+        }
+        helpers = new Helpers(s, 'stub')
+    })
+
+    test('setInput should be called with an empty string',()=>{
+        helpers.clearInput()
+        expect(setInputSpy).toHaveBeenCalledWith('')
+    })
+})
+
+describe('SetFocus tests',()=>{
+    let helpers: Helpers
+    let reference: {current:{focus: jest.Mock}}
+    let focusSpy: jest.Mock
+    beforeEach(() => {
+        jest.resetAllMocks()
+        focusSpy = jest.fn()
+        reference = {current:{focus: focusSpy}}
+        const s = {setInput: jest.fn, setIsLoading: jest.fn(), reference: reference}
+        helpers = new Helpers(s, 'stub')
+    })
+
+    test('setFocus should call the reference current.focus',()=>{
+        helpers.setFocus();
+        expect(focusSpy).toHaveBeenCalled()
+    })
+
 })
 
 const keyEvent=(key: string) =>{

--- a/__tests__/components/Messages.test.tsx
+++ b/__tests__/components/Messages.test.tsx
@@ -70,7 +70,7 @@ describe('Messages renders with correct content', () => {
 
         const sessionId = 'rose-16'
         const {getByText} = render(<Messages initialMessages={[msg]} sessionId={sessionId}/>)
-       const time = getByText("1729667463")
+        const time = getByText("1729667463")
         expect(time).toBeInTheDocument()
     })
 })

--- a/__tests__/components/Messages.test.tsx
+++ b/__tests__/components/Messages.test.tsx
@@ -6,7 +6,7 @@ import React from "react";
 
 describe('Messages renders with correct content', () => {
     test('renders with a div labeled "messages"', () => {
-        const {getByLabelText} = render(<Messages initialMessages={[]}/>)
+        const {getByLabelText} = render(<Messages initialMessages={[]} sessionId="stub"/>)
         const div = getByLabelText('messages')
         expect(div).toBeInTheDocument();
     })
@@ -17,7 +17,7 @@ describe('Messages renders with correct content', () => {
             text: 'Hello World',
             timestamp: 0
         }
-        const {getByText} = render(<Messages initialMessages={[msg]}/>)
+        const {getByText} = render(<Messages initialMessages={[msg]} sessionId='stub'/>)
         const div = getByText('Hello World')
         expect(div).toBeInTheDocument();
     })
@@ -28,8 +28,49 @@ describe('Messages renders with correct content', () => {
             text: "My name's Gypsy. What's yours?",
             timestamp: 0
         }
-        const {getByText} = render(<Messages initialMessages={[msg]}/>)
+        const {getByText} = render(<Messages initialMessages={[msg]} sessionId='stub'/>)
         const div = getByText("My name's Gypsy. What's yours?")
         expect(div).toBeInTheDocument();
+    })
+    test('if the message is from the sessionId, then display it with white text and a blue background',()=>{
+        const msg: Message = {
+            id: 'stub',
+            senderId:'louise-99',
+            text: "My name's Gypsy. What's yours?",
+            timestamp: 0
+        }
+
+        const sessionId = 'louise-99'
+        const {getByText} = render(<Messages initialMessages={[msg]} sessionId={sessionId}/>)
+        const span = getByText("My name's Gypsy. What's yours?")
+        expect(span).toHaveClass('bg-blue-800')
+        expect(span).toHaveClass('text-white')
+    })
+    test('if the message is not from sessionId, then display it with dark grey text and a light grey background',()=>{
+        const msg: Message = {
+            id: 'stub',
+            senderId:'louise-99',
+            text: "My name's Gypsy. What's yours?",
+            timestamp: 0
+        }
+
+        const sessionId = 'rose-16'
+        const {getByText} = render(<Messages initialMessages={[msg]} sessionId={sessionId}/>)
+        const span = getByText("My name's Gypsy. What's yours?")
+        expect(span).toHaveClass('bg-gray-200')
+        expect(span).toHaveClass('text-gray-900')
+    })
+    test('Message should display the time sent', ()=>{
+        const msg: Message = {
+            id: 'stub',
+            senderId:'louise-99',
+            text: "My name's Gypsy. What's yours?",
+            timestamp: 1729667463
+        }
+
+        const sessionId = 'rose-16'
+        const {getByText} = render(<Messages initialMessages={[msg]} sessionId={sessionId}/>)
+       const time = getByText("1729667463")
+        expect(time).toBeInTheDocument()
     })
 })

--- a/__tests__/components/Messages.test.tsx
+++ b/__tests__/components/Messages.test.tsx
@@ -1,11 +1,24 @@
 import '@testing-library/jest-dom';
-import {render} from "@testing-library/react";
+import { render} from "@testing-library/react";
 import Messages from "@/components/Messages";
+import {Message} from "@/lib/validations/messages"
+import React from "react";
 
-describe('Messages renders with correct components', () => {
+describe('Messages renders with correct content', () => {
     test('renders with a div labeled "messages"', () => {
-        const {getByLabelText} = render(<Messages/>)
+        const {getByLabelText} = render(<Messages initialMessages={[]}/>)
         const div = getByLabelText('messages')
+        expect(div).toBeInTheDocument();
+    })
+    test('a message passed to the component is on the screen',()=>{
+        const msg: Message = {
+            id: 'stub',
+            senderId:'stub',
+            text: 'stub',
+            timestamp: 0
+        }
+        const {getByText} = render(<Messages initialMessages={[msg]}/>)
+        const div = getByText('Hello World')
         expect(div).toBeInTheDocument();
     })
 })

--- a/__tests__/components/Messages.test.tsx
+++ b/__tests__/components/Messages.test.tsx
@@ -14,11 +14,22 @@ describe('Messages renders with correct content', () => {
         const msg: Message = {
             id: 'stub',
             senderId:'stub',
-            text: 'stub',
+            text: 'Hello World',
             timestamp: 0
         }
         const {getByText} = render(<Messages initialMessages={[msg]}/>)
         const div = getByText('Hello World')
+        expect(div).toBeInTheDocument();
+    })
+    test('a message passed to the component is on the screen, different data',()=>{
+        const msg: Message = {
+            id: 'stub',
+            senderId:'stub',
+            text: "My name's Gypsy. What's yours?",
+            timestamp: 0
+        }
+        const {getByText} = render(<Messages initialMessages={[msg]}/>)
+        const div = getByText("My name's Gypsy. What's yours?")
         expect(div).toBeInTheDocument();
     })
 })

--- a/__tests__/components/Messages.test.tsx
+++ b/__tests__/components/Messages.test.tsx
@@ -1,0 +1,11 @@
+import '@testing-library/jest-dom';
+import {render} from "@testing-library/react";
+import Messages from "@/components/Messages";
+
+describe('Messages renders with correct components', () => {
+    test('renders with a div labeled "messages"', () => {
+        const {getByLabelText} = render(<Messages/>)
+        const div = getByLabelText('messages')
+        expect(div).toBeInTheDocument();
+    })
+})

--- a/__tests__/lib/queryBuilder.test.ts
+++ b/__tests__/lib/queryBuilder.test.ts
@@ -25,8 +25,12 @@ describe('QueryBuilder.join Test', () => {
     test('Should return user:dracula:friends', () => {
         expect(QueryBuilder.join('dracula', 'friends')).toEqual('user:dracula:friends');
     });
-    test('Should return user:dracula:friends', () => {
+    test('Should return user:dracula:incoming_friend_requests', () => {
         expect(QueryBuilder.join('dracula', 'incoming_friend_requests')).toEqual('user:dracula:incoming_friend_requests');
+    });
+
+    test('Should return user:frankenstein:friends', () => {
+        expect(QueryBuilder.join('frankenstein', 'incoming_friend_requests')).toEqual('user:frankenstein:incoming_friend_requests');
     });
 
 });

--- a/__tests__/lib/queryBuilder.test.ts
+++ b/__tests__/lib/queryBuilder.test.ts
@@ -1,0 +1,5 @@
+describe('QueryBuilder Test', () => {
+    test('Should return user:{id}', () => {
+        expect(QueryBuilder.user('1234')).toEqual('user:1234')
+    })
+})

--- a/__tests__/lib/queryBuilder.test.ts
+++ b/__tests__/lib/queryBuilder.test.ts
@@ -4,4 +4,8 @@ describe('QueryBuilder Test', () => {
     test('Should return user:{id}', () => {
         expect(QueryBuilder.user('1234')).toEqual('user:1234')
     })
+
+    test('Should return user:{id}, different data', () => {
+        expect(QueryBuilder.user('frank')).toEqual('user:frank')
+    })
 })

--- a/__tests__/lib/queryBuilder.test.ts
+++ b/__tests__/lib/queryBuilder.test.ts
@@ -1,11 +1,22 @@
 import QueryBuilder from "@/lib/queryBuilder";
 
-describe('QueryBuilder Test', () => {
+describe('QueryBuilder.user Test', () => {
     test('Should return user:{id}', () => {
         expect(QueryBuilder.user('1234')).toEqual('user:1234');
     });
 
     test('Should return user:{id}, different data', () => {
         expect(QueryBuilder.user('frank')).toEqual('user:frank');
+    });
+});
+
+
+describe('QueryBuilder.incomingFriendRequests Test', () => {
+    test('Should return user:{id}:incoming_friend_requests', () => {
+        expect(QueryBuilder.incomingFriendRequests('1234')).toEqual('user:1234:incoming_friend_requests');
+    });
+
+    test('Should return user:{id}:incoming_friend_requests', () => {
+        expect(QueryBuilder.incomingFriendRequests('frank')).toEqual('user:frank:incoming_friend_requests');
     });
 });

--- a/__tests__/lib/queryBuilder.test.ts
+++ b/__tests__/lib/queryBuilder.test.ts
@@ -1,6 +1,6 @@
 import QueryBuilder from "@/lib/queryBuilder";
 
-describe('QueryBuilder.user Test', () => {
+describe('QueryBuilder.user Tests', () => {
     test('Should return user:{id}', () => {
         expect(QueryBuilder.user('1234')).toEqual('user:1234');
     });
@@ -11,7 +11,7 @@ describe('QueryBuilder.user Test', () => {
 });
 
 
-describe('QueryBuilder.incomingFriendRequests Test', () => {
+describe('QueryBuilder.incomingFriendRequests Tests', () => {
     test('Should return user:{id}:incoming_friend_requests', () => {
         expect(QueryBuilder.incomingFriendRequests('1234')).toEqual('user:1234:incoming_friend_requests');
     });
@@ -21,7 +21,7 @@ describe('QueryBuilder.incomingFriendRequests Test', () => {
     });
 });
 
-describe('QueryBuilder.join Test', () => {
+describe('QueryBuilder.join Tests', () => {
     test('Should return user:dracula:friends', () => {
         expect(QueryBuilder.join('dracula', 'friends')).toEqual('user:dracula:friends');
     });
@@ -32,5 +32,14 @@ describe('QueryBuilder.join Test', () => {
     test('Should return user:frankenstein:friends', () => {
         expect(QueryBuilder.join('frankenstein', 'incoming_friend_requests')).toEqual('user:frankenstein:incoming_friend_requests');
     });
-
 });
+
+describe('QueryBuilder.email Tests', () => {
+    test('Should return user:email:foo@bar.com', () => {
+        expect(QueryBuilder.email('foo@bar.com')).toEqual('user:email:foo@bar.com');
+    })
+
+    test('Should return user:email:bar@foo.com', () => {
+        expect(QueryBuilder.email('bar@foo.com')).toEqual('user:email:bar@foo.com');
+    })
+})

--- a/__tests__/lib/queryBuilder.test.ts
+++ b/__tests__/lib/queryBuilder.test.ts
@@ -1,3 +1,5 @@
+import QueryBuilder from "@/lib/queryBuilder";
+
 describe('QueryBuilder Test', () => {
     test('Should return user:{id}', () => {
         expect(QueryBuilder.user('1234')).toEqual('user:1234')

--- a/__tests__/lib/queryBuilder.test.ts
+++ b/__tests__/lib/queryBuilder.test.ts
@@ -2,10 +2,10 @@ import QueryBuilder from "@/lib/queryBuilder";
 
 describe('QueryBuilder Test', () => {
     test('Should return user:{id}', () => {
-        expect(QueryBuilder.user('1234')).toEqual('user:1234')
-    })
+        expect(QueryBuilder.user('1234')).toEqual('user:1234');
+    });
 
     test('Should return user:{id}, different data', () => {
-        expect(QueryBuilder.user('frank')).toEqual('user:frank')
-    })
-})
+        expect(QueryBuilder.user('frank')).toEqual('user:frank');
+    });
+});

--- a/__tests__/lib/queryBuilder.test.ts
+++ b/__tests__/lib/queryBuilder.test.ts
@@ -20,3 +20,13 @@ describe('QueryBuilder.incomingFriendRequests Test', () => {
         expect(QueryBuilder.incomingFriendRequests('frank')).toEqual('user:frank:incoming_friend_requests');
     });
 });
+
+describe('QueryBuilder.join Test', () => {
+    test('Should return user:dracula:friends', () => {
+        expect(QueryBuilder.join('dracula', 'friends')).toEqual('user:dracula:friends');
+    });
+    test('Should return user:dracula:friends', () => {
+        expect(QueryBuilder.join('dracula', 'incoming_friend_requests')).toEqual('user:dracula:incoming_friend_requests');
+    });
+
+});

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     images: {
+        /** user images are assumed to be sourced from google **/
         domains: ["lh3.googleusercontent.com"],
     },
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    images: {
+        domains: ['media.wired.com'],
+    },
+};
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     images: {
-        domains: ['media.wired.com', "i.kym-cdn.com"],
+        domains: ["lh3.googleusercontent.com"],
     },
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     images: {
-        domains: ['media.wired.com'],
+        domains: ['media.wired.com', "i.kym-cdn.com"],
     },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.53.0",
         "react-hot-toast": "^2.4.1",
+        "react-textarea-autosize": "^8.5.4",
         "tailwind-merge": "^2.5.3",
         "zod": "^3.23.8"
       },
@@ -10056,6 +10057,23 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.4.tgz",
+      "integrity": "sha512-eSSjVtRLcLfFwFcariT77t9hcbVJHQV76b51QjQGarQIHml2+gM2lms0n3XrhnDmgK5B+/Z7TmQk5OHNzqYm/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -11509,6 +11527,46 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.53.0",
     "react-hot-toast": "^2.4.1",
+    "react-textarea-autosize": "^8.5.4",
     "tailwind-merge": "^2.5.3",
     "zod": "^3.23.8"
   },

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/helpers.ts
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/helpers.ts
@@ -3,7 +3,7 @@ import fetchRedis from "@/helpers/redis";
 import {messageArraySchema} from "@/lib/validations/messages";
 
 export class Helpers{
-    async getChatMessage(chatId: string){
+    async getChatMessages(chatId: string){
         try{
             const chats = await this.fetchChatById(chatId);
             const formattedChats = chats.map(chat => JSON.parse(chat) as Message)

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -21,7 +21,14 @@ const Page: FC<ChatProps> = async ({params}) => {
 
     const partnerId = userId === participants[0] ? participants[1] : participants[0]
     const partner = (await db.get(`user:${partnerId}`)) as User
+    return<Display partner={partner}/>
+}
 
+interface DisplayProps {
+    partner: User
+}
+
+const Display: FC<DisplayProps> = ({partner}) =>{
     return<div className='chat-a'>
         <div className='chat-b'>
             <div className='chat-c'>
@@ -48,6 +55,5 @@ const Page: FC<ChatProps> = async ({params}) => {
         </div>
     </div>
 }
-
 
 export default Page;

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -27,6 +27,11 @@ class Participants{
     partnerId(): string{
         return this.userA == this.sessionId? this.userB : this.userA;
     }
+
+    getPartnerQuery():string{
+        /** note, this template string is EVERYWHERE, why not use some kind of utils function?**/
+        return `user:${this.partnerId()}`
+    }
 }
 
 interface ChatProps{
@@ -43,11 +48,10 @@ const Page: FC<ChatProps> = async ({params}) => {
     const helpers = new Helpers()
     const initialMessages = await helpers.getChatMessages(chatId)
 
-    if (!(session && participants.includesSession())){
+    if (!participants.includesSession()){
         notFound();
     }
-
-    const partner = (await db.get(`user:${participants.partnerId()}`)) as User;
+    const partner = (await db.get(participants.getPartnerQuery())) as User;
 
     return<Display partner={partner} messages={initialMessages} userId={userId} chatId={chatId}/>
 }

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -26,16 +26,16 @@ const Page: FC<ChatProps> = async ({params}) => {
         <div className='chat-b'>
             <div className='chat-c'>
                 <div className='relative'>
-                    <div className='chat-image'>
+                    <div className='chat-d'>
                         <Image src={partner.image}
                                fill
                                alt={partner.name}
                                referrerPolicy='no-referrer'
-                               className='rounded-full ml-3'/>
+                               className='chat-image'/>
                     </div>
                 </div>
-                <div className='flex flex-col leading-tight'>
-                    <div className='text-xl flex items-center'>
+                <div className='chat-e'>
+                    <div className='chat-f'>
                         <span className='text-gray-700 ml-3 font-semibold'>
                             {partner.name}
                         </span>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -15,7 +15,7 @@ const Page: FC<ChatProps> = async ({params}) => {
     const userId = session?.user?.id
     const participants = params.chatId.split('--')
 
-    if (!session || !participants.includes(userId as string)){
+    if (!(session && participants.includes(userId as string))){
         notFound();
     }
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -37,7 +37,7 @@ const Page: FC<ChatProps> = async ({params}) => {
                 <div className='flex flex-col leading-tight'>
                     <div className='text-xl flex items-center'>
                         <span className='text-gray-700 ml-3 font-semibold'>
-                            alice
+                            {partner.name}
                         </span>
                     </div>
                 </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -14,7 +14,7 @@ const Page: FC<ChatProps> = async ({params}) => {
     if (!session || !params.chatId.split('--').includes(session.user.id)){
         notFound();
     }
-    const imageSource ="https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"
+    const imageSource ="https://i.kym-cdn.com/entries/icons/original/000/023/846/lisa.jpg"
 
     return<div className='flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]'>
         <div className='flex sm:items-center justify-between py-3 border-b-2 border-gray-200'>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -12,18 +12,20 @@ interface ChatProps{
 
 const Page: FC<ChatProps> = async ({params}) => {
     const session = await myGetServerSession();
-    if (!session || !params.chatId.split('--').includes(session.user.id)){
+    const participants = params.chatId.split('--')
+    if (!session || !participants.includes(session.user.id)){
         notFound();
+        return
     }
-
-    const partner = (await db.get('user:spock')) as User
+    const partnerId = session.user.id === 'kirk' ? 'spock' : 'kirk'
+    const partner = (await db.get(`user:${partnerId}`)) as User
 
     return<div className='flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]'>
         <div className='flex sm:items-center justify-between py-3 border-b-2 border-gray-200'>
             <div className='relative flex items-center space-x-4'>
                 <div className='relative'>
                     <div className='relative w-8 sm:w-12 sm:h-12'>
-                        <Image src={partner.image} fill alt={'pikachu'} referrerPolicy='no-referrer'/>
+                        <Image src={partner.image} fill alt='partner name' referrerPolicy='no-referrer'/>
                     </div>
                 </div>
             </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -34,7 +34,13 @@ const Page: FC<ChatProps> = async ({params}) => {
                                className='rounded-full ml-3'/>
                     </div>
                 </div>
-                <div><div><span>alice</span></div></div>
+                <div className='flex flex-col leading-tight'>
+                    <div className='text-xl flex items-center'>
+                        <span className='text-gray-700 ml-3 font-semibold'>
+                            alice
+                        </span>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -36,11 +36,13 @@ const Page: FC<ChatProps> = async ({params}) => {
                 </div>
                 <div className='chat-e'>
                     <div className='chat-f'>
-                        <span className='text-gray-700 ml-3 font-semibold'>
+                        <span className='chat-g'>
                             {partner.name}
                         </span>
                     </div>
-                    <span>spock@vulcanscience.edu</span>
+                    <span className='chat-h'>
+                        spock@vulcanscience.edu
+                    </span>
                 </div>
             </div>
         </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -2,6 +2,7 @@ import {FC} from "react";
 import {notFound} from "next/navigation";
 import myGetServerSession from "@/lib/myGetServerSession";
 import Image from "next/image";
+import {db} from "@/lib/db";
 
 interface ChatProps{
     params: {
@@ -14,7 +15,9 @@ const Page: FC<ChatProps> = async ({params}) => {
     if (!session || !params.chatId.split('--').includes(session.user.id)){
         notFound();
     }
-    const imageSource ="https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"
+
+    const partner = (await db.get('foo')) as User
+    const imageSource = partner.image
 
     return<div className='flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]'>
         <div className='flex sm:items-center justify-between py-3 border-b-2 border-gray-200'>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -15,9 +15,9 @@ const Page: FC<ChatProps> = async ({params}) => {
     const participants = params.chatId.split('--')
     if (!session || !participants.includes(session.user.id)){
         notFound();
-        return
     }
-    const partnerId = session.user.id === 'kirk' ? 'spock' : 'kirk'
+
+    const partnerId = session?.user?.id === 'kirk' ? 'spock' : 'kirk'
     const partner = (await db.get(`user:${partnerId}`)) as User
 
     return<div className='chat-a'>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -25,7 +25,7 @@ const Page: FC<ChatProps> = async ({params}) => {
             <div className='chat-c'>
                 <div className='relative'>
                     <div className='chat-image'>
-                        <Image src={partner.image} fill alt='fooey' referrerPolicy='no-referrer'/>
+                        <Image src={partner.image} fill alt={partner.name} referrerPolicy='no-referrer'/>
                     </div>
                 </div>
             </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -53,6 +53,7 @@ const Display: FC<DisplayProps> = ({partner}) =>{
                 </div>
             </div>
         </div>
+        <div aria-label='messages'/>
     </div>
 }
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -12,12 +12,14 @@ interface ChatProps{
 
 const Page: FC<ChatProps> = async ({params}) => {
     const session = await myGetServerSession();
+    const userId = session?.user?.id
     const participants = params.chatId.split('--')
-    if (!session || !participants.includes(session.user.id)){
+
+    if (!session || !userId){
         notFound();
     }
 
-    const partnerId = session?.user?.id === participants[0] ? participants[1] : participants[0]
+    const partnerId = userId === participants[0] ? participants[1] : participants[0]
     const partner = (await db.get(`user:${partnerId}`)) as User
 
     return<div className='chat-a'>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -7,6 +7,7 @@ import Messages from "@/components/Messages";
 import {Helpers} from "@/app/(dashboard)/dashboard/chat/[chatId]/helpers";
 import {Message} from "@/lib/validations/messages";
 import ChatInput from "@/components/ChatInput/ChatInput";
+import QueryBuilder from "@/lib/queryBuilder";
 
 class Participants{
     private readonly userA: string
@@ -29,8 +30,7 @@ class Participants{
     }
 
     getPartnerQuery():string{
-        /** note, this template string is EVERYWHERE, why not use some kind of utils function?**/
-        return `user:${this.partnerId()}`
+        return QueryBuilder.user(this.partnerId());
     }
 }
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -17,7 +17,7 @@ const Page: FC<ChatProps> = async ({params}) => {
         notFound();
     }
 
-    const partnerId = session?.user?.id === 'kirk' ? 'spock' : 'kirk'
+    const partnerId = session?.user?.id === participants[0] ? participants[1] : participants[0]
     const partner = (await db.get(`user:${partnerId}`)) as User
 
     return<div className='chat-a'>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -15,7 +15,7 @@ const Page: FC<ChatProps> = async ({params}) => {
     const userId = session?.user?.id
     const participants = params.chatId.split('--')
 
-    if (!session || !userId){
+    if (!session || !participants.includes(userId as string)){
         notFound();
     }
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -14,8 +14,9 @@ const Page: FC<ChatProps> = async ({params}) => {
     if (!session || !params.chatId.split('--').includes(session.user.id)){
         notFound();
     }
+    const imageSource ="https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"
 
-    return <div><Image src={"https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"} width="40" height="40" alt={'pikachu'}/></div>
+    return <div><Image src={imageSource} width="40" height="40" alt={'pikachu'}/></div>
 }
 
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -25,7 +25,7 @@ const Page: FC<ChatProps> = async ({params}) => {
             <div className='relative flex items-center space-x-4'>
                 <div className='relative'>
                     <div className='relative w-8 sm:w-12 sm:h-12'>
-                        <Image src={partner.image} fill alt='partner name' referrerPolicy='no-referrer'/>
+                        <Image src={partner.image} fill alt='fooey' referrerPolicy='no-referrer'/>
                     </div>
                 </div>
             </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -27,7 +27,11 @@ const Page: FC<ChatProps> = async ({params}) => {
             <div className='chat-c'>
                 <div className='relative'>
                     <div className='chat-image'>
-                        <Image src={partner.image} fill alt={partner.name} referrerPolicy='no-referrer'/>
+                        <Image src={partner.image}
+                               fill
+                               alt={partner.name}
+                               referrerPolicy='no-referrer'
+                               className='rounded-full ml-3'/>
                     </div>
                 </div>
             </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -41,7 +41,7 @@ const Page: FC<ChatProps> = async ({params}) => {
                         </span>
                     </div>
                     <span className='chat-h'>
-                        spock@vulcanscience.edu
+                        {partner.email}
                     </span>
                 </div>
             </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -1,6 +1,7 @@
 import {FC} from "react";
 import {notFound} from "next/navigation";
 import myGetServerSession from "@/lib/myGetServerSession";
+import Image from "next/image";
 
 interface ChatProps{
     params: {
@@ -14,7 +15,7 @@ const Page: FC<ChatProps> = async ({params}) => {
         notFound();
     }
 
-    return <div/>
+    return <div><Image src={"https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"} width="40" height="40" alt={'pikachu'}/></div>
 }
 
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -16,7 +16,7 @@ const Page: FC<ChatProps> = async ({params}) => {
         notFound();
     }
 
-    const partner = (await db.get('foo')) as User
+    const partner = (await db.get('user:spock')) as User
 
     return<div className='flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]'>
         <div className='flex sm:items-center justify-between py-3 border-b-2 border-gray-200'>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -16,7 +16,17 @@ const Page: FC<ChatProps> = async ({params}) => {
     }
     const imageSource ="https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"
 
-    return <div><Image src={imageSource} width="40" height="40" alt={'pikachu'}/></div>
+    return<div className='flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]'>
+        <div className='flex sm:items-center justify-between py-3 border-b-2 border-gray-200'>
+            <div className='relative flex items-center space-x-4'>
+                <div className='relative'>
+                    <div className='relative w-8 sm:w-12 sm:h-12'>
+                        <Image src={imageSource} fill alt={'pikachu'} referrerPolicy='no-referrer'/>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 }
 
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -40,6 +40,7 @@ const Page: FC<ChatProps> = async ({params}) => {
                             {partner.name}
                         </span>
                     </div>
+                    <span>spock@vulcanscience.edu</span>
                 </div>
             </div>
         </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -34,6 +34,7 @@ const Page: FC<ChatProps> = async ({params}) => {
                                className='rounded-full ml-3'/>
                     </div>
                 </div>
+                <div><div><span>alice</span></div></div>
             </div>
         </div>
     </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -54,7 +54,7 @@ const Display: FC<DisplayProps> = ({partner}) =>{
                 </div>
             </div>
         </div>
-        <Messages/>
+        <Messages initialMessages={[]}/>
     </div>
 }
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -17,14 +17,13 @@ const Page: FC<ChatProps> = async ({params}) => {
     }
 
     const partner = (await db.get('foo')) as User
-    const imageSource = partner.image
 
     return<div className='flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]'>
         <div className='flex sm:items-center justify-between py-3 border-b-2 border-gray-200'>
             <div className='relative flex items-center space-x-4'>
                 <div className='relative'>
                     <div className='relative w-8 sm:w-12 sm:h-12'>
-                        <Image src={imageSource} fill alt={'pikachu'} referrerPolicy='no-referrer'/>
+                        <Image src={partner.image} fill alt={'pikachu'} referrerPolicy='no-referrer'/>
                     </div>
                 </div>
             </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -14,7 +14,7 @@ const Page: FC<ChatProps> = async ({params}) => {
     if (!session || !params.chatId.split('--').includes(session.user.id)){
         notFound();
     }
-    const imageSource ="https://i.kym-cdn.com/entries/icons/original/000/023/846/lisa.jpg"
+    const imageSource ="https://media.wired.com/photos/5f87340d114b38fa1f8339f9/master/w_1600,c_limit/Ideas_Surprised_Pikachu_HD.jpg"
 
     return<div className='flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]'>
         <div className='flex sm:items-center justify-between py-3 border-b-2 border-gray-200'>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -3,6 +3,7 @@ import {notFound} from "next/navigation";
 import myGetServerSession from "@/lib/myGetServerSession";
 import Image from "next/image";
 import {db} from "@/lib/db";
+import Messages from "@/components/Messages";
 
 interface ChatProps{
     params: {
@@ -53,7 +54,7 @@ const Display: FC<DisplayProps> = ({partner}) =>{
                 </div>
             </div>
         </div>
-        <div aria-label='messages'/>
+        <Messages/>
     </div>
 }
 

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -20,11 +20,11 @@ const Page: FC<ChatProps> = async ({params}) => {
     const partnerId = session.user.id === 'kirk' ? 'spock' : 'kirk'
     const partner = (await db.get(`user:${partnerId}`)) as User
 
-    return<div className='flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]'>
-        <div className='flex sm:items-center justify-between py-3 border-b-2 border-gray-200'>
-            <div className='relative flex items-center space-x-4'>
+    return<div className='chat-a'>
+        <div className='chat-b'>
+            <div className='chat-c'>
                 <div className='relative'>
-                    <div className='relative w-8 sm:w-12 sm:h-12'>
+                    <div className='chat-image'>
                         <Image src={partner.image} fill alt='fooey' referrerPolicy='no-referrer'/>
                     </div>
                 </div>

--- a/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[chatId]/page.tsx
@@ -6,6 +6,7 @@ import {db} from "@/lib/db";
 import Messages from "@/components/Messages";
 import {Helpers} from "@/app/(dashboard)/dashboard/chat/[chatId]/helpers";
 import {Message} from "@/lib/validations/messages";
+import ChatInput from "@/components/ChatInput/ChatInput";
 
 class Participants{
     private readonly userA: string
@@ -48,19 +49,21 @@ const Page: FC<ChatProps> = async ({params}) => {
 
     const partner = (await db.get(`user:${participants.partnerId()}`)) as User;
 
-    return<Display partner={partner} messages={initialMessages} userId={userId}/>
+    return<Display partner={partner} messages={initialMessages} userId={userId} chatId={chatId}/>
 }
 
 interface DisplayProps {
     partner: User
     messages: Message[]
     userId: string
+    chatId: string
 }
 
-const Display: FC<DisplayProps> = ({partner, messages, userId}) =>{
+const Display: FC<DisplayProps> = ({partner, messages, userId, chatId}) =>{
     return<div className='chat-a'>
         <Header partner = {partner}/>
         <Messages initialMessages={messages} sessionId={userId}/>
+        <ChatInput chatPartner={partner} chatId={chatId}/>
     </div>
 }
 

--- a/src/app/(dashboard)/dashboard/layout.tsx
+++ b/src/app/(dashboard)/dashboard/layout.tsx
@@ -9,6 +9,7 @@ import myGetServerSession from "@/lib/myGetServerSession";
 import SignOutButton from "@/components/signOutButton";
 import getFriendsById from "@/helpers/getFriendsById";
 import SidebarChatList from "@/components/SidebarChatList";
+import QueryBuilder from "@/lib/queryBuilder";
 
 interface LayoutProps {
     children: ReactNode
@@ -23,7 +24,7 @@ const Layout = async ({children}: LayoutProps = {children:null})=>{
 
     const userId = session?.user?.id
 
-    const friendRequests = await fetchRedis("smembers", `user:${userId}:incoming_friend_requests`);
+    const friendRequests = await fetchRedis("smembers", QueryBuilder.incomingFriendRequests(userId));
 
     const friendRequestProps = {
         initialRequestCount: friendRequests.length,
@@ -31,6 +32,7 @@ const Layout = async ({children}: LayoutProps = {children:null})=>{
     }
 
     const friends = await getFriendsById(userId);
+
     return<div className='dashboard-window'>
         <div className='dashboard'>
         <Link href="/dashboard" className='dashboard-link'>

--- a/src/app/(dashboard)/dashboard/requests/getFriendRequests.ts
+++ b/src/app/(dashboard)/dashboard/requests/getFriendRequests.ts
@@ -2,7 +2,7 @@ import fetchRedis from "@/helpers/redis";
 import QueryBuilder from "@/lib/queryBuilder";
 
 async function getFriendRequests(sessionId:string): Promise<{senderId: string, senderEmail:string}[]> {
-   const ids = await fetchRedis('smembers', `user:${sessionId}:incoming_friend_requests`) as string[]
+   const ids = await fetchRedis('smembers', QueryBuilder.incomingFriendRequests(sessionId)) as string[]
 
 
     const requests = await Promise.all(

--- a/src/app/(dashboard)/dashboard/requests/getFriendRequests.ts
+++ b/src/app/(dashboard)/dashboard/requests/getFriendRequests.ts
@@ -1,4 +1,5 @@
 import fetchRedis from "@/helpers/redis";
+import QueryBuilder from "@/lib/queryBuilder";
 
 async function getFriendRequests(sessionId:string): Promise<{senderId: string, senderEmail:string}[]> {
    const ids = await fetchRedis('smembers', `user:${sessionId}:incoming_friend_requests`) as string[]
@@ -6,8 +7,8 @@ async function getFriendRequests(sessionId:string): Promise<{senderId: string, s
 
     const requests = await Promise.all(
         ids.map(async id => {
-            const sender = await fetchRedis('get', `user:${id}`) as string;
-            const parsed =JSON.parse(sender) as User
+            const sender = await fetchRedis('get', QueryBuilder.user(id)) as string;
+            const parsed = JSON.parse(sender) as User
             return{
                 senderId:id,
                 senderEmail:parsed.email

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -2,6 +2,7 @@ import {z} from 'zod'
 import myGetServerSession from "@/lib/myGetServerSession";
 import fetchRedis from "@/helpers/redis";
 import {db} from "@/lib/db";
+import QueryBuilder from "@/lib/queryBuilder";
 
 export async function POST(request: Request):Promise<Response> {
     const idToAdd = await getIdToAdd(request);
@@ -76,7 +77,7 @@ class Handler{
     }
 
     userTable(id: string, suffix: 'friends'| 'incoming_friend_requests'){
-        return `user:${id}:${suffix}`; //find a way to fold this into query builder
+        return QueryBuilder.join(id, suffix);
     }
 }
 

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -76,7 +76,7 @@ class Handler{
     }
 
     userTable(id: string, suffix: 'friends'| 'incoming_friend_requests'){
-        return `user:${id}:${suffix}`;
+        return `user:${id}:${suffix}`; //find a way to fold this into query builder
     }
 }
 

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -2,6 +2,7 @@ import {addFriendValidator} from "@/lib/validations/add-friend";
 import myGetServerSession from "@/lib/myGetServerSession";
 import fetchRedis from "@/helpers/redis";
 import {db} from "@/lib/db";
+import QueryBuilder from "@/lib/queryBuilder";
 
 interface errorProps{
     message: string,
@@ -68,12 +69,12 @@ export class PostFriendsRouteHandler {
     }
 
     async userExists(email:string):Promise<boolean>{
-        this.idToAdd = await fetchRedis("get",`user:email:${email}`)
+        this.idToAdd = await fetchRedis("get",QueryBuilder.email(email))
         return Boolean(this.idToAdd)
     }
 
     async redisSismember(userId: string, list: 'incoming_friend_requests' | 'friends', queryId:string):Promise<boolean>{
-        const result = await fetchRedis("sismember",  `user:${userId}:${list}`,queryId) as 0 | 1
+        const result = await fetchRedis("sismember",  QueryBuilder.join(userId, list), queryId) as 0 | 1
         return Boolean(result)
     }
 
@@ -86,7 +87,7 @@ export class PostFriendsRouteHandler {
     }
 
     async addToDB():Promise<void>{
-        await db.sadd(`user:${this.idToAdd}:incoming_friend_requests`,this.senderId )
+        await db.sadd(QueryBuilder.incomingFriendRequests(this.idToAdd),this.senderId )
     }
 
     isSameUser():boolean{

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -191,7 +191,7 @@
     @apply fixed bottom-8 dashboard-sub-ul
 }
 
-.chat-image{
+.chat-d{
     @apply relative w-8 sm:w-12 sm:h-12
 }
 
@@ -205,4 +205,20 @@
 
 .chat-c{
     @apply relative flex items-center space-x-4
+}
+
+.chat-image{
+    @apply rounded-full ml-3
+}
+
+.chat-e{
+    @apply flex flex-col leading-tight
+}
+
+.chat-f{
+    @apply text-xl flex items-center
+}
+
+.chat-g{
+    @apply text-gray-700 ml-3 font-semibold
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -253,3 +253,15 @@
 }
 
 .scrolling-touch { -webkit-overflow-scrolling: touch; }
+
+.message-div-2{
+    @apply flex flex-col space-y-2 text-base max-w-xs mx-2
+}
+
+.message-span{
+    @apply px-4 py-2 rounded-lg inline-block
+}
+
+.message-date{
+    @apply ml-2 text-xs text-gray-400
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,7 +196,7 @@
 }
 
 .chat-a{
-    @apply flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)
+    @apply flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)]
 }
 
 .chat-b{

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -190,3 +190,19 @@
 .signout-ul{
     @apply fixed bottom-8 dashboard-sub-ul
 }
+
+.chat-image{
+    @apply relative w-8 sm:w-12 sm:h-12
+}
+
+.chat-a{
+    @apply flex-1 justify-between flex flex-col h-full max-h-[calc(100vh-6rem)
+}
+
+.chat-b{
+    @apply flex sm:items-center justify-between py-3 border-b-2 border-gray-200
+}
+
+.chat-c{
+    @apply relative flex items-center space-x-4
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -265,3 +265,19 @@
 .message-date{
     @apply ml-2 text-xs text-gray-400
 }
+
+.chat-input-a {
+    @apply border-t border-gray-200 px-4 pt-4 mb-2 sm:mb-0
+}
+
+.chat-input-b{
+    @apply relative flex-1 overflow-hidden rounded-lg shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-indigo-600
+}
+
+.chat-input-c{
+    @apply block w-full resize-none border-0 bg-transparent text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:py-1.5 sm:text-sm sm:leading-6
+}
+
+.chat-input-d{
+    @apply absolute right-0 bottom-0 flex justify-between py-2 pl-3 pr-2
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -226,3 +226,30 @@
 .chat-h{
     @apply text-sm ml-3 text-gray-600
 }
+
+.message-scroll{
+    @apply flex h-full flex-1 flex-col-reverse gap-4 p-3 overflow-y-auto scrollbar-thumb-blue scrollbar-thumb-rounded scrollbar-track-blue-lighter scrollbar-w-2 scrolling-touch
+}
+
+.scrollbar-w-2::-webkit-scrollbar {
+    width: 0.25rem;
+    height:0.25rem;
+}
+
+.scrollbar-track-blue-lighter::-webkit-scrollbar-track {
+    --bg-opacity:1;
+    background-color: #f7fafc;
+    background-color: rgba(247, 250, 252, var(--bg-opacity));
+}
+
+.scrollbar-thumb-blue::-webkit-scrollbar-thumb {
+    --bg-opacity:1;
+    background-color: #edf2f7;
+    background-color: rgba(237, 242, 247, var(--bg-opacity));
+}
+
+.scrollbar-thumb-rounded::-webkit-scrollbar-thumb {
+    border-radius:0.25rem;
+}
+
+.scrolling-touch { -webkit-overflow-scrolling: touch; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -222,3 +222,7 @@
 .chat-g{
     @apply text-gray-700 ml-3 font-semibold
 }
+
+.chat-h{
+    @apply text-sm ml-3 text-gray-600
+}

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import React, {FC, useRef, useState} from "react";
+import TextareaAutosize from 'react-textarea-autosize';
+import {sendMessage} from "@/components/ChatInput/helpers";
+
+interface ChatInputProps {}
+
+
+const ChatInput:FC<ChatInputProps> = ({})=>{
+    const [input, setInput] = useState("");
+    //use reference to the DOM text area element, default to null
+    const textAreaRef = useRef<HTMLTextAreaElement| null>(null)
+
+    return (<div>
+        <div>
+            <TextareaAutosize ref={textAreaRef}
+                              aria-label='autosize field'
+                              onKeyDown={(event) => sendMessage(event)}
+                              value={input}
+                              onChange={event => setInput(event.target.value)}
+                              placeholder='Message Batman'
+            />
+        </div>
+    </div>)
+}
+
+export default  ChatInput

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -2,27 +2,56 @@
 
 import React, {FC, useRef, useState} from "react";
 import TextareaAutosize from 'react-textarea-autosize';
-import {sendMessage} from "@/components/ChatInput/helpers";
+import Helpers from "@/components/ChatInput/helpers";
+import Button from "@/components/ui/button/Button";
 
-interface ChatInputProps {}
+interface ChatInputProps {
+    chatPartner: User,
+    chatId: string,
+}
 
 
-const ChatInput:FC<ChatInputProps> = ({})=>{
+const ChatInput:FC<ChatInputProps> = ({chatPartner, chatId})=>{
     const [input, setInput] = useState("");
-    //use reference to the DOM text area element, default to null
+    const [isLoading, setIsLoading] = useState(false);
     const textAreaRef = useRef<HTMLTextAreaElement| null>(null)
+    const setterParams = {setIsLoading, setInput, reference: textAreaRef}
+    const helpers = new Helpers(setterParams, chatId)
 
-    return (<div>
-        <div>
-            <TextareaAutosize ref={textAreaRef}
-                              aria-label='autosize field'
-                              onKeyDown={(event) => sendMessage(event)}
-                              value={input}
-                              onChange={event => setInput(event.target.value)}
-                              placeholder='Message Batman'
-            />
+    return (
+        <div aria-label='chat input' className='chat-input-a'>
+            <div className='chat-input-b'>
+                <TextareaAutosize ref={textAreaRef}
+                                  aria-label='autosize field'
+                                  placeholder={`Send ${chatPartner.name} a message`}
+                                  onKeyDown={(event) => helpers.HandleKeystroke(event, input)}
+                                  onChange={event => setInput(event.target.value)}
+                                  value={input}
+                                  rows={1}
+                                  className='chat-input-c'
+                />
+
+                <div className="py-2"
+                     aria-hidden="true"
+                     onClick={() => helpers.setFocus()}
+                >
+                    <div className="py-px">
+                        <div className="h-9"/>
+                    </div>
+                </div>
+            </div>
+
+            <div className="chat-input-d">
+                <div className="flex-shrink-0">
+                    <Button onClick={()=> helpers.SendMessage(input)}
+                    isLoading={isLoading}
+                    >
+                        Send
+                    </Button>
+                </div>
+            </div>
         </div>
-    </div>)
+    )
 }
 
 export default  ChatInput

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -10,7 +10,6 @@ interface ChatInputProps {
     chatId: string,
 }
 
-
 const ChatInput:FC<ChatInputProps> = ({chatPartner, chatId})=>{
     const [input, setInput] = useState("");
     const [isLoading, setIsLoading] = useState(false);

--- a/src/components/ChatInput/helpers.ts
+++ b/src/components/ChatInput/helpers.ts
@@ -1,5 +1,6 @@
 import React from "react";
-import axios from "axios";
+import axios, {AxiosError} from "axios";
+import {toast} from "react-hot-toast";
 
 interface StateSetters {
     setIsLoading : React.Dispatch<React.SetStateAction<boolean>>
@@ -39,7 +40,7 @@ export default class Helpers{
            this.clearInput()
            this.setFocus()
        }catch(error){
-            console.error({error})
+                toast.error((error as AxiosError)?.message || 'Something went wrong. Try again')
        }finally{
            this.setters.setIsLoading(false)
        }

--- a/src/components/ChatInput/helpers.ts
+++ b/src/components/ChatInput/helpers.ts
@@ -18,8 +18,12 @@ export default class Helpers{
         this.chatId = chatId
     }
 
+    isUnShiftedEnter(event: React.KeyboardEvent<HTMLTextAreaElement>){
+        return event.key === "Enter" && !event.shiftKey
+    }
+
     HandleKeystroke  (event: React.KeyboardEvent<HTMLTextAreaElement>, input:string) {
-        if (event.key === "Enter" && !event.shiftKey) {
+        if (this.isUnShiftedEnter(event)) {
             event.preventDefault();
             this.SendMessage(input);
         }

--- a/src/components/ChatInput/helpers.ts
+++ b/src/components/ChatInput/helpers.ts
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const sendMessage = (event: React.KeyboardEvent<HTMLTextAreaElement>)=>{
+    if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault()
+    }
+}

--- a/src/components/ChatInput/helpers.ts
+++ b/src/components/ChatInput/helpers.ts
@@ -1,7 +1,47 @@
 import React from "react";
+import axios from "axios";
 
-export const sendMessage = (event: React.KeyboardEvent<HTMLTextAreaElement>)=>{
-    if (event.key === "Enter" && !event.shiftKey) {
-        event.preventDefault()
+interface StateSetters {
+    setIsLoading : React.Dispatch<React.SetStateAction<boolean>>
+    setInput : React.Dispatch<React.SetStateAction<string>>
+    reference:  React.MutableRefObject<HTMLTextAreaElement | null>
+}
+
+export default class Helpers{
+    setters : StateSetters
+    chatId: string
+    endpoint: string = '/api/message/send'
+
+    constructor( setters: StateSetters, chatId: string) {
+        this.setters = setters;
+        this.chatId = chatId
     }
+
+    HandleKeystroke  (event: React.KeyboardEvent<HTMLTextAreaElement>, input:string) {
+        if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            this.SendMessage(input);
+        }
+    }
+
+    clearInput(){
+        this.setters.setInput('')
+    }
+
+    setFocus(){
+        this.setters.reference.current?.focus()
+    }
+
+   async SendMessage(input: string){
+        this.setters.setIsLoading(true)
+       try{
+           await axios.post(this.endpoint,{text: input, chatId: this.chatId})
+           this.clearInput()
+           this.setFocus()
+       }catch(error){
+            console.error({error})
+       }finally{
+           this.setters.setIsLoading(false)
+       }
+   }
 }

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -6,11 +6,9 @@ import {Message} from "@/lib/validations/messages"
 interface MessagesProps {
     initialMessages: Message[]
 }
-const Messages: FC<MessagesProps> = ({initialMessages}) => {
+const Messages: FC<MessagesProps> = () => {
     return <div aria-label='messages' className='message-scroll'>
-        <div>
            Hello World
-        </div>
     </div>
 }
 export default Messages;

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -1,8 +1,16 @@
 'use client'
 
 import {FC} from "react";
+import {Message} from "@/lib/validations/messages"
 
-const Messages: FC = () => {
-    return <div aria-label='messages' className='message-scroll'/>
+interface MessagesProps {
+    initialMessages: Message[]
+}
+const Messages: FC<MessagesProps> = ({initialMessages}) => {
+    return <div aria-label='messages' className='message-scroll'>
+        <div>
+           Hello World
+        </div>
+    </div>
 }
 export default Messages;

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -15,8 +15,8 @@ const Messages: FC<MessagesProps> = ({initialMessages, sessionId}) => {
     return <div aria-label='messages' className='message-scroll'>
         <div ref={scrollDownRef}>
         {messages.map((message, index) => {
-            const foo = messages[index - 1]?.senderId === messages[index].senderId
-            const classes = new ClassNames(sessionId === message.senderId, foo)
+            const hasNextMessage = userHasNextMessage(messages, index)
+            const classes = new ClassNames(sessionId === message.senderId, hasNextMessage)
 
             return (
                <div key={listKey(message)} className={classes.div1}>
@@ -40,6 +40,9 @@ const listKey = (message: Message) =>{
     return `${id}-${timestamp}`
 }
 
+const userHasNextMessage = (messages: Message[], ndx: number) =>{
+    return messages[ndx - 1]?.senderId === messages[ndx].senderId
+}
 
 class ClassNames {
     private readonly isCurrentUser: boolean
@@ -50,7 +53,7 @@ class ClassNames {
         this.hasNextMessage = hasNextMessageFromSameUser
     }
 
-    class(base: string, ifIsUserId: string, ifNotUserId: string | null = null){
+    className(base: string, ifIsUserId: string, ifNotUserId: string | null = null){
         const suffix = this.isCurrentUser ? ifIsUserId : ifNotUserId
         if (!suffix){
             return base
@@ -59,11 +62,11 @@ class ClassNames {
     }
 
     get div1(): string{
-        return this.class('flex items-end', 'justify-end')
+        return this.className('flex items-end', 'justify-end')
     }
 
     get div2(): string{
-        return this.class('message-div-2','order-1 items-end', 'order-2 items-start' )
+        return this.className('message-div-2','order-1 items-end', 'order-2 items-start' )
     }
 
     bubble(isSpeechBalloon: boolean): string{
@@ -75,7 +78,7 @@ class ClassNames {
             partnerStyling += ' rounded-br-none'
         }
 
-        return this.class('px-4 py-2 rounded-lg inline-block', currentUserStyling, partnerStyling )
+        return this.className('px-4 py-2 rounded-lg inline-block', currentUserStyling, partnerStyling )
     }
 
    get span(): string{

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -6,9 +6,10 @@ import {Message} from "@/lib/validations/messages"
 interface MessagesProps {
     initialMessages: Message[]
 }
-const Messages: FC<MessagesProps> = () => {
+const Messages: FC<MessagesProps> = (props: MessagesProps) => {
+    const p = props
     return <div aria-label='messages' className='message-scroll'>
-           Hello World
+        {p.initialMessages.length > 0 ? p.initialMessages[0].text: null}
     </div>
 }
 export default Messages;

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -1,18 +1,23 @@
 'use client'
 
-import {FC, useState} from "react";
+import {FC, useRef, useState} from "react";
 import {Message} from "@/lib/validations/messages"
 
 interface MessagesProps {
     initialMessages: Message[],
     sessionId: string
 }
+
 const Messages: FC<MessagesProps> = ({initialMessages, sessionId}) => {
     const [messages, setMessages] = useState<Message[]>(initialMessages)
+    const scrollDownRef = useRef<HTMLDivElement | null>(null)
+
     return <div aria-label='messages' className='message-scroll'>
+        <div ref={scrollDownRef}>
         {messages.map((message, index) => {
             const foo = messages[index - 1]?.senderId === messages[index].senderId
             const classes = new ClassNames(sessionId === message.senderId, foo)
+
             return (
                <div key={listKey(message)} className={classes.div1}>
                    <div className={classes.div2}>
@@ -26,6 +31,7 @@ const Messages: FC<MessagesProps> = ({initialMessages, sessionId}) => {
                </div>
            )
         })}
+    </div>
     </div>
 }
 

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -3,6 +3,6 @@
 import {FC} from "react";
 
 const Messages: FC = () => {
-    return <div aria-label='messages'/>
+    return <div aria-label='messages' className='message-scroll'/>
 }
 export default Messages;

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import {FC} from "react";
+
+const Messages: FC = () => {
+    return <div aria-label='messages'/>
+}
+export default Messages;

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -1,15 +1,80 @@
 'use client'
 
-import {FC} from "react";
+import {FC, useState} from "react";
 import {Message} from "@/lib/validations/messages"
 
 interface MessagesProps {
-    initialMessages: Message[]
+    initialMessages: Message[],
+    sessionId: string
 }
-const Messages: FC<MessagesProps> = (props: MessagesProps) => {
-    const p = props
+const Messages: FC<MessagesProps> = ({initialMessages, sessionId}) => {
+    const [messages, setMessages] = useState<Message[]>(initialMessages)
     return <div aria-label='messages' className='message-scroll'>
-        {p.initialMessages.length > 0 ? p.initialMessages[0].text: null}
+        {messages.map((message, index) => {
+            const foo = messages[index - 1]?.senderId === messages[index].senderId
+            const classes = new ClassNames(sessionId === message.senderId, foo)
+            return (
+               <div key={listKey(message)} className={classes.div1}>
+                   <div className={classes.div2}>
+                       <span className={classes.span}>
+                           {message.text}{' '}
+                           <span className='message-date'>
+                               {message.timestamp}
+                           </span>
+                       </span>
+                   </div>
+               </div>
+           )
+        })}
     </div>
 }
+
+const listKey = (message: Message) =>{
+    const {id, timestamp} = message
+    return `${id}-${timestamp}`
+}
+
+
+class ClassNames {
+    private readonly isCurrentUser: boolean
+    private readonly hasNextMessage: boolean
+
+    constructor(isCurrentUser: boolean, hasNextMessageFromSameUser: boolean) {
+        this.isCurrentUser = isCurrentUser
+        this.hasNextMessage = hasNextMessageFromSameUser
+    }
+
+    class(base: string, ifIsUserId: string, ifNotUserId: string | null = null){
+        const suffix = this.isCurrentUser ? ifIsUserId : ifNotUserId
+        if (!suffix){
+            return base
+        }
+        return `${base} ${suffix}`
+    }
+
+    get div1(): string{
+        return this.class('flex items-end', 'justify-end')
+    }
+
+    get div2(): string{
+        return this.class('message-div-2','order-1 items-end', 'order-2 items-start' )
+    }
+
+    bubble(isSpeechBalloon: boolean): string{
+        let currentUserStyling = 'bg-blue-800 text-white'
+        let partnerStyling = 'bg-gray-200 text-gray-900'
+
+        if (isSpeechBalloon){
+            currentUserStyling += ' rounded-bl-none'
+            partnerStyling += ' rounded-br-none'
+        }
+
+        return this.class('px-4 py-2 rounded-lg inline-block', currentUserStyling, partnerStyling )
+    }
+
+   get span(): string{
+        return this.bubble(!this.hasNextMessage )
+   }
+}
+
 export default Messages;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import { UpstashRedisAdapter } from '@next-auth/upstash-redis-adapter'
 import { db } from './db'
 import GoogleProvider from 'next-auth/providers/google'
 import  fetchRedis  from '@/helpers/redis'
+import QueryBuilder from "@/lib/queryBuilder";
 
 const  getGoogleCredentials =() =>{
     const clientId = process.env.GOOGLE_CLIENT_ID
@@ -36,7 +37,7 @@ const authOptions: NextAuthOptions = {
     ],
     callbacks: {
         async jwt({ token, user }) {
-            const dbUserResult = (await fetchRedis('get', `user:${token.id}`)) as
+            const dbUserResult = (await fetchRedis('get', QueryBuilder.user(token.id))) as
                 | string
                 | null
 

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -1,5 +1,5 @@
 export default class QueryBuilder {
-    static user(){
+    static user(userId: string): QueryBuilder {
         return 'foo'
     }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -1,13 +1,22 @@
 export default class QueryBuilder {
     static user(userId: string): string {
-        return `user:${userId}`;
+        return this._append(userId)
+    }
+
+    private static _append( ...args: string[]): string {
+        args.unshift('user')
+        return args.join(':');
     }
 
     static incomingFriendRequests(userId: string): string {
-        return `${this.user(userId)}:incoming_friend_requests`
+        return this.join(userId, 'incoming_friend_requests')
     }
 
     static join(userId: string, suffix: string): string {
-        return `${this.user(userId)}:${suffix}`
+        return this._append(userId, suffix)
+    }
+
+    static email(email: string): string {
+       return  this._append('email', email)
     }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -1,5 +1,9 @@
 export default class QueryBuilder {
-    static user(userId: string): QueryBuilder {
+    static user(userId: string): string {
         return `user:${userId}`;
+    }
+
+    static incomingFriendRequests(userId: string): string {
+        return this.user(userId) + ':incoming_friend_requests'
     }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -1,0 +1,5 @@
+export default class QueryBuilder {
+    static user(){
+        return 'foo'
+    }
+}

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -8,6 +8,6 @@ export default class QueryBuilder {
     }
 
     static join(userId: string, suffix: string): string {
-        return 'user:dracula:' + suffix;
+        return `${this.user(userId)}:${suffix}`
     }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -1,5 +1,5 @@
 export default class QueryBuilder {
     static user(userId: string): QueryBuilder {
-        return 'user:1234'
+        return `user:${userId}`
     }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -1,5 +1,5 @@
 export default class QueryBuilder {
     static user(userId: string): QueryBuilder {
-        return 'foo'
+        return 'user:1234'
     }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -6,4 +6,8 @@ export default class QueryBuilder {
     static incomingFriendRequests(userId: string): string {
         return `${this.user(userId)}:incoming_friend_requests`
     }
+
+    static join(userId: string, suffix: string): string {
+        return 'user:dracula:' + suffix;
+    }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -1,5 +1,5 @@
 export default class QueryBuilder {
     static user(userId: string): QueryBuilder {
-        return `user:${userId}`
+        return `user:${userId}`;
     }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -4,6 +4,6 @@ export default class QueryBuilder {
     }
 
     static incomingFriendRequests(userId: string): string {
-        return this.user(userId) + ':incoming_friend_requests'
+        return `${this.user(userId)}:incoming_friend_requests`
     }
 }


### PR DESCRIPTION
This branch continues the user-side invocation of the chat functionality. The chats are sorted by chat id, and the chat ID page contains a couple of subcomponents: Messages and ChatInput. The ChatId page's functionality itself has also been extended.

The Messsages component displays messages retrieved from the backend and styles them according to whether the sender is the session user or their correspondent.

The ChatInput component uses an api endpoint that hasn't been implemented yet, styled and setup to use an as-yet not implemented API endpoint. It uses 'react-textarea-autosize' plugin.

A function signature has already been updated.

To sum up, this should be everything a user needs to send chat messages short of the API itself.