### PR TITLE
Realtime friend requests

### DIFF
--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -356,11 +356,11 @@ describe("triggerPusherServer tests", ()=>{
 
     test('if the id to add is 1235, then the first argument passed to server.trigger is user__1235__friend_requests',()=>{
         handler.triggerPusherServer('1235')
-        expect(triggerSpy).toHaveBeenCalledWith('user__1235__friend_requests', expect.anything(), expect.anything());
+        expect(triggerSpy).toHaveBeenCalledWith('user__1235__incoming_friend_requests', expect.anything(), expect.anything());
     })
 
     test('if the id to add is 1701, then the first argument passed to server.trigger is user__1701__friend_requests',()=>{
         handler.triggerPusherServer('1701')
-        expect(triggerSpy).toHaveBeenCalledWith('user__1701__friend_requests', expect.anything(), expect.anything());
+        expect(triggerSpy).toHaveBeenCalledWith('user__1701__incoming_friend_requests', expect.anything(), expect.anything());
     })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -340,10 +340,16 @@ describe("isSameUserTests",()=>{
 });
 
 describe("triggerPusherServer tests", ()=>{
-    test('should call pusherServer trigger',()=>{
-        const handler = new PostFriendsRouteHandler();
-        const triggerSpy = jest.fn();
+    let handler: PostFriendsRouteHandler;
+    let triggerSpy: jest.Mock;
+
+    beforeEach(()=>{
+        handler = new PostFriendsRouteHandler();
+        triggerSpy = jest.fn();
         (getPusherServer as jest.Mock).mockReturnValue({trigger: triggerSpy});
+    })
+
+    test('should call pusherServer trigger',()=>{
         handler.triggerPusherServer()
         expect(triggerSpy).toHaveBeenCalled();
     })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -369,8 +369,9 @@ describe("triggerPusherServer tests", ()=>{
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), 'incoming_friend_requests', expect.anything());
     })
 
-    test('the third  argument passed to server.trigger is {senderId: mork, senderEmail: mork@ork.nanu}',()=>{
+    test('the third  argument passed to server.trigger contains {senderId: mork',()=>{
         handler.triggerPusherServer()
-        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({senderId: 'mork'}));
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
+            expect.objectContaining({senderId: 'mork'}));
     })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -354,7 +354,7 @@ describe("triggerPusherServer tests", ()=>{
         expect(triggerSpy).toHaveBeenCalled();
     })
 
-    test('if the id to add is 1235, then the first argument passed to server.trigger is user__1235__friend_requests',()=>{
+    test('if the id to add is 1235, then the first argument passed to server.trigger is user__1235__incoming_friend_requests',()=>{
         handler.triggerPusherServer('1235')
         expect(triggerSpy).toHaveBeenCalledWith('user__1235__incoming_friend_requests', expect.anything(), expect.anything());
     })
@@ -362,5 +362,10 @@ describe("triggerPusherServer tests", ()=>{
     test('if the id to add is 1701, then the first argument passed to server.trigger is user__1701__friend_requests',()=>{
         handler.triggerPusherServer('1701')
         expect(triggerSpy).toHaveBeenCalledWith('user__1701__incoming_friend_requests', expect.anything(), expect.anything());
+    })
+
+    test('the second argument passed to server.trigger is incoming_friend_requests',()=>{
+        handler.triggerPusherServer()
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), 'incoming_friend_requests', expect.anything());
     })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -370,14 +370,20 @@ describe("triggerPusherServer tests", ()=>{
     })
 
     test('the third  argument passed to server.trigger contains {senderId: mork',()=>{
-        handler.triggerPusherServer()
+        handler.triggerPusherServer('mindy', {senderId:'mork'})
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
             expect.objectContaining({senderId: 'mork'}));
     })
 
     test('the third  argument passed to server.trigger contains {senderId: mindy',()=>{
-        handler.triggerPusherServer()
+        handler.triggerPusherServer('mork', {senderId: 'mindy'})
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
             expect.objectContaining({senderId: 'mindy'}));
+    })
+
+    test('the third  argument passed to server.trigger contains {senderEmail: mindy@colorado.earth',()=>{
+        handler.triggerPusherServer('mork', {senderId: 'mindy'})
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
+            expect.objectContaining({senderEmail: 'mindy@colorado.earth'}));
     })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -358,4 +358,9 @@ describe("triggerPusherServer tests", ()=>{
         handler.triggerPusherServer()
         expect(triggerSpy).toHaveBeenCalledWith('user__1235__friend_requests', expect.anything(), expect.anything());
     })
+
+    test('if the id to add is 1701, then the first argument passed to server.trigger is user__1701__friend_requests',()=>{
+        handler.triggerPusherServer()
+        expect(triggerSpy).toHaveBeenCalledWith('user__1701__friend_requests', expect.anything(), expect.anything());
+    })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -1,7 +1,7 @@
 import {PostFriendsRouteHandler} from '@/app/api/friends/add/handler'
 import fetchRedis from "@/helpers/redis"
 import { db } from '@/lib/db';
-import {getPusherClient, getPusherServer} from "@/lib/pusher";
+import { getPusherServer} from "@/lib/pusher";
 
 jest.mock("@/lib/myGetServerSession",()=>({
     __esModule: true,
@@ -370,20 +370,26 @@ describe("triggerPusherServer tests", ()=>{
     })
 
     test('the third  argument passed to server.trigger contains {senderId: mork',()=>{
-        handler.triggerPusherServer('mindy', {senderId:'mork'})
+        handler.triggerPusherServer('mindy', {senderId:'mork', senderEmail: 'mork@ork.nanu'})
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
             expect.objectContaining({senderId: 'mork'}));
     })
 
     test('the third  argument passed to server.trigger contains {senderId: mindy',()=>{
-        handler.triggerPusherServer('mork', {senderId: 'mindy'})
+        handler.triggerPusherServer('mork', {senderId: 'mindy', senderEmail: 'mindy@colorado.earth'})
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
             expect.objectContaining({senderId: 'mindy'}));
     })
 
     test('the third  argument passed to server.trigger contains {senderEmail: mindy@colorado.earth',()=>{
-        handler.triggerPusherServer('mork', {senderId: 'mindy'})
+        handler.triggerPusherServer('mork', {senderId: 'mindy', senderEmail: 'mindy@colorado.earth'})
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
             expect.objectContaining({senderEmail: 'mindy@colorado.earth'}));
+    })
+
+    test('the third  argument passed to server.trigger contains {senderEmail: mork@ork.nanu',()=>{
+        handler.triggerPusherServer('mork', {senderId: 'mork', senderEmail: 'mork@ork.nanu'})
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
+            expect.objectContaining({senderEmail: 'mork@ork.nanu'}));
     })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -353,4 +353,9 @@ describe("triggerPusherServer tests", ()=>{
         handler.triggerPusherServer()
         expect(triggerSpy).toHaveBeenCalled();
     })
+
+    test('if the id to add is 1235, then the first argument passed to server.trigger is user__1235__friend_requests',()=>{
+        handler.triggerPusherServer()
+        expect(triggerSpy).toHaveBeenCalledWith('user__1235__friend_requests', expect.anything(), expect.anything());
+    })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -1,6 +1,7 @@
 import {PostFriendsRouteHandler} from '@/app/api/friends/add/handler'
 import fetchRedis from "@/helpers/redis"
 import { db } from '@/lib/db';
+import {getPusherClient, getPusherServer} from "@/lib/pusher";
 
 jest.mock("@/lib/myGetServerSession",()=>({
     __esModule: true,
@@ -17,6 +18,10 @@ jest.mock("@/lib/db",()=>({
     db: {
         sadd: jest.fn() // Mock the sadd method
     }
+}));
+
+jest.mock("@/lib/pusher",()=>({
+    getPusherServer: jest.fn()
 }));
 
 describe('Validate Tests - true verses false', () => {
@@ -333,3 +338,13 @@ describe("isSameUserTests",()=>{
         expect(handler.isSameUser()).toEqual(false);
     });
 });
+
+describe("triggerPusherServer tests", ()=>{
+    test('should call pusherServer trigger',()=>{
+        const handler = new PostFriendsRouteHandler();
+        const triggerSpy = jest.fn();
+        (getPusherServer as jest.Mock).mockReturnValue({trigger: triggerSpy});
+        handler.triggerPusherServer()
+        expect(triggerSpy).toHaveBeenCalled();
+    })
+})

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -355,12 +355,12 @@ describe("triggerPusherServer tests", ()=>{
     })
 
     test('if the id to add is 1235, then the first argument passed to server.trigger is user__1235__friend_requests',()=>{
-        handler.triggerPusherServer()
+        handler.triggerPusherServer('1235')
         expect(triggerSpy).toHaveBeenCalledWith('user__1235__friend_requests', expect.anything(), expect.anything());
     })
 
     test('if the id to add is 1701, then the first argument passed to server.trigger is user__1701__friend_requests',()=>{
-        handler.triggerPusherServer()
+        handler.triggerPusherServer('1701')
         expect(triggerSpy).toHaveBeenCalledWith('user__1701__friend_requests', expect.anything(), expect.anything());
     })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -374,4 +374,10 @@ describe("triggerPusherServer tests", ()=>{
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
             expect.objectContaining({senderId: 'mork'}));
     })
+
+    test('the third  argument passed to server.trigger contains {senderId: mindy',()=>{
+        handler.triggerPusherServer()
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(),
+            expect.objectContaining({senderId: 'mindy'}));
+    })
 })

--- a/__tests__/app/api/friends/add/route.test.ts
+++ b/__tests__/app/api/friends/add/route.test.ts
@@ -368,4 +368,9 @@ describe("triggerPusherServer tests", ()=>{
         handler.triggerPusherServer()
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), 'incoming_friend_requests', expect.anything());
     })
+
+    test('the third  argument passed to server.trigger is {senderId: mork, senderEmail: mork@ork.nanu}',()=>{
+        handler.triggerPusherServer()
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({senderId: 'mork'}));
+    })
 })

--- a/__tests__/components/FriendRequests/FriendRequests.test.tsx
+++ b/__tests__/components/FriendRequests/FriendRequests.test.tsx
@@ -47,33 +47,33 @@ describe('FriendRequests', () => {
     });
 
     test('final state of friend requests is 0, should render "Nothing to show here..." ',()=>{
-        render(<FriendRequests incomingFriendRequests={[]} />);
+        render(<FriendRequests incomingFriendRequests={[]} sessionId='stub' />);
         const text = screen.getByText('Nothing to show here...');
         expect(text).toBeInTheDocument();
     });
 
     test('if the component receives a list of length 2, then there should be two UserPlus icons in the document',
         ()=>{
-        render(<FriendRequests incomingFriendRequests = {requests1}/>);
+        render(<FriendRequests incomingFriendRequests = {requests1} sessionId='stub'/>);
         const icons = screen.getAllByLabelText('add user');
         expect(icons).toHaveLength(2);
     });
 
     test('if the component receives a list of length 2, then there should be two UserPlus icons in the document',
         ()=>{
-        render(<FriendRequests incomingFriendRequests = {requests2} />);
+        render(<FriendRequests incomingFriendRequests = {requests2} sessionId='stub' />);
         const icons = screen.getAllByLabelText('add user');
         expect(icons).toHaveLength(1);
     });
 
     test('if (final) requests are greater than 0, do not render "Nothing to show here...',()=>{
-        render(<FriendRequests incomingFriendRequests = {requests1}/>);
+        render(<FriendRequests incomingFriendRequests = {requests1} sessionId='stub'/>);
         const text = screen.queryByText('Nothing to show here...');
         expect(text).not.toBeInTheDocument();
     });
 
     test('sender emails should be listed',()=>{
-        const {queryByText} =render(<FriendRequests incomingFriendRequests ={requests1}/>);
+        const {queryByText} =render(<FriendRequests incomingFriendRequests ={requests1} sessionId='stub'/>);
         const button1 = queryByText('foo@bar.com');
         const button2 = queryByText('bar@foo.com');
         expect(button1).toBeInTheDocument();
@@ -82,19 +82,19 @@ describe('FriendRequests', () => {
 
     test('if the component receives a list of length 2, then there should be two elements with the label "accept friend"',
         ()=>{
-        render(<FriendRequests incomingFriendRequests = {requests1}/>);
+        render(<FriendRequests incomingFriendRequests = {requests1} sessionId='stub'/>);
         const buttons = screen.getAllByLabelText(/accept friend*/i);
         expect(buttons).toHaveLength(2);
     });
 
     test('elements with the label "accept friend" should be a button',()=>{
-        render(<FriendRequests incomingFriendRequests = {requests2}/>);
+        render(<FriendRequests incomingFriendRequests = {requests2} sessionId='stub'/>);
         const button = screen.getByLabelText(/accept friend*/i);
         expect(button.tagName).toBe('BUTTON');
     });
 
     test('accept friend should contain a checkmark',()=>{
-        render(<FriendRequests incomingFriendRequests = {requests2}/>);
+        render(<FriendRequests incomingFriendRequests = {requests2} sessionId='stub'/>);
         const button = screen.getByLabelText(/accept friend*/i);
         const check = within(button).getByLabelText('checkmark');
         expect(check).toBeInTheDocument();
@@ -102,19 +102,19 @@ describe('FriendRequests', () => {
 
     test('if the component receives a list of length 2, then there should be two elements with the label "deny friend"',
         ()=>{
-        render(<FriendRequests incomingFriendRequests = {requests1}/>);
+        render(<FriendRequests incomingFriendRequests = {requests1} sessionId='stub'/>);
         const buttons = screen.getAllByLabelText(/deny friend*/i);
         expect(buttons).toHaveLength(2);
     });
 
     test('elements with the label "deny friend" should be a button',()=>{
-        render(<FriendRequests incomingFriendRequests = {requests2}/>);
+        render(<FriendRequests incomingFriendRequests = {requests2} sessionId='stub'/>);
         const button = screen.getByLabelText(/deny friend*/i);
         expect(button.tagName).toBe('BUTTON');
     });
 
     test('deny friend should contain a x',()=>{
-        render(<FriendRequests incomingFriendRequests = {requests2}/>);
+        render(<FriendRequests incomingFriendRequests = {requests2} sessionId='stub'/>);
         const button = screen.getByLabelText(/deny friend*/i);
         const check = within(button).getByLabelText('x');
         expect(check).toBeInTheDocument();
@@ -122,7 +122,7 @@ describe('FriendRequests', () => {
 
     test('when accept friend is clicked, axios should be called with the endpoint /api/friends/accept',
         async ()=>{
-        const {getByLabelText} = render(<FriendRequests incomingFriendRequests = {requests2}/>);
+        const {getByLabelText} = render(<FriendRequests incomingFriendRequests = {requests2} sessionId='stub'/>);
         const button = getByLabelText(/accept friend*/i);
         fireEvent.click(button);
 
@@ -132,7 +132,7 @@ describe('FriendRequests', () => {
     });
 
     test('when accept friend is clicked, axios should be called with the opts {id: senderId}', async ()=>{
-        const {getByLabelText} = render(<FriendRequests incomingFriendRequests = {requests2}/>);
+        const {getByLabelText} = render(<FriendRequests incomingFriendRequests = {requests2} sessionId='stub'/>);
         const button = getByLabelText(/accept friend*/i);
         fireEvent.click(button);
 
@@ -143,7 +143,7 @@ describe('FriendRequests', () => {
 
     test('when accept friend is clicked, axios should be called with the opts {id: senderId}, different data',
         async ()=>{
-        const {getByLabelText} =  render(<FriendRequests incomingFriendRequests = {requests2}/>);
+        const {getByLabelText} =  render(<FriendRequests incomingFriendRequests = {requests2} sessionId='stub'/>);
         const button = getByLabelText(/accept friend*/i);
         fireEvent.click(button);
 
@@ -154,7 +154,7 @@ describe('FriendRequests', () => {
 
     test('if accept friend is clicked,  current id should be removed from page',
         async ()=>{
-            const {getByRole} = render(<FriendRequests incomingFriendRequests={requests3} />);
+            const {getByRole} = render(<FriendRequests incomingFriendRequests={requests3} sessionId='stub' />);
             const button = getByRole('button', {
                 name: /accept friend: fredo@correlone.edu/i
             });
@@ -174,7 +174,7 @@ describe('FriendRequests', () => {
             refresh: spy
         });
 
-        const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} />);
+        const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} sessionId='stub' />);
         const button = getByLabelText(/accept friend*/i);
         fireEvent.click(button);
         await waitFor(()=>{
@@ -183,7 +183,7 @@ describe('FriendRequests', () => {
     });
 
     test('when deny friend is clicked, axios should be called with /api/friends/deny', async ()=>{
-            const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} />);
+            const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} sessionId='stub'/>);
             const button = getByLabelText(/deny friend*/i);
             fireEvent.click(button);
             await waitFor(()=>{
@@ -192,7 +192,7 @@ describe('FriendRequests', () => {
         });
 
     test('when deny friend is clicked, axios should be called with the opts {id: senderId}', async ()=>{
-        const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} />);
+        const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} sessionId='stub'/>);
         const button = getByLabelText(/deny friend*/i);
         fireEvent.click(button);
         await waitFor(()=>{
@@ -202,7 +202,7 @@ describe('FriendRequests', () => {
 
     test('when deny friend is clicked, axios should be called with the opts {id: senderId}, different data',
         async ()=>{
-            const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} />);
+            const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} sessionId='stub'/>);
             const button = getByLabelText(/deny friend*/i);
             fireEvent.click(button);
             await waitFor(()=>{
@@ -212,7 +212,7 @@ describe('FriendRequests', () => {
 
     test('if deny friend is clicked, current sender id should be removed',
         async ()=>{
-            const {getByRole} = render(<FriendRequests incomingFriendRequests={requests3} />);
+            const {getByRole} = render(<FriendRequests incomingFriendRequests={requests3} sessionId='stub'/>);
             const button = getByRole('button', {
                 name: /deny friend: fredo@correlone.edu/i
             });
@@ -232,7 +232,7 @@ describe('FriendRequests', () => {
             refresh: spy,
         });
 
-        const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} />);
+        const {getByLabelText} = render(<FriendRequests incomingFriendRequests={requests2} sessionId='stub'/>);
         const button = getByLabelText(/deny friend*/i);
         fireEvent.click(button);
         await waitFor(()=>{

--- a/__tests__/components/FriendRequests/FriendRequests.test.tsx
+++ b/__tests__/components/FriendRequests/FriendRequests.test.tsx
@@ -247,15 +247,13 @@ describe('FriendRequest realtime functionality', () => {
         (subscribeToPusherClient as jest.Mock).mockImplementation(jest.fn());
     });
 
-    test('Rendering the component should call UseEffect', ()=>{
-        const useEffectSpy = jest.spyOn(React, 'useEffect')
-        render(<FriendRequests incomingFriendRequests={[]} />);
-        expect (useEffectSpy).toHaveBeenCalled();
+    test('The rendered component should be called with method subscribeToPusherClient',()=>{
+        render(<FriendRequests incomingFriendRequests={[]} sessionId='stub' />);
+        expect(subscribeToPusherClient).toHaveBeenCalledWith('stub');
     });
 
     test('The rendered component should be called with method subscribeToPusherClient',()=>{
-        const useEffectSpy = jest.spyOn(React, 'useEffect');
-        render(<FriendRequests incomingFriendRequests={[]} />);
-        expect (useEffectSpy).toHaveBeenCalledWith(subscribeToPusherClient, expect.anything());
+        render(<FriendRequests incomingFriendRequests={[]} sessionId='other_stub' />);
+        expect(subscribeToPusherClient).toHaveBeenCalledWith('other_stub');
     });
 });

--- a/__tests__/components/FriendRequests/FriendRequests.test.tsx
+++ b/__tests__/components/FriendRequests/FriendRequests.test.tsx
@@ -4,15 +4,17 @@ import {render, screen, waitFor, within, fireEvent} from "@testing-library/react
 import React from "react";
 import axios from 'axios';
 import {useRouter} from "next/navigation";
-import subscribeToPusherClient from "@/components/FriendRequests/helpers"
+import PusherClientHandler from "@/components/FriendRequests/helpers";
 
 jest.mock('next/navigation', () => ({
     useRouter: jest.fn(),
 }));
 
-jest.mock("@/components/FriendRequests/helpers", () => {
-    return jest.fn()
-});
+jest.mock("@/lib/pusher",()=>({
+    getPusherClient: jest.fn()
+}));
+
+jest.spyOn(PusherClientHandler.prototype, 'subscribeToPusherClient').mockImplementation(jest.fn());
 
 jest.mock('axios');
 
@@ -242,18 +244,14 @@ describe('FriendRequests', () => {
 });
 
 describe('FriendRequest realtime functionality', () => {
+    let subscribeSpy: jest.SpyInstance
     beforeEach(()=>{
-        jest.resetAllMocks();
-        (subscribeToPusherClient as jest.Mock).mockImplementation(jest.fn());
+        subscribeSpy = jest.fn();
+        subscribeSpy = jest.spyOn(PusherClientHandler.prototype, 'subscribeToPusherClient').mockReturnValue(jest.fn())
     });
 
     test('The rendered component should be called with method subscribeToPusherClient',()=>{
         render(<FriendRequests incomingFriendRequests={[]} sessionId='stub' />);
-        expect(subscribeToPusherClient).toHaveBeenCalledWith('stub');
-    });
-
-    test('The rendered component should be called with method subscribeToPusherClient',()=>{
-        render(<FriendRequests incomingFriendRequests={[]} sessionId='other_stub' />);
-        expect(subscribeToPusherClient).toHaveBeenCalledWith('other_stub');
+        expect(subscribeSpy).toHaveBeenCalled();
     });
 });

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -46,4 +46,9 @@ describe('subscribeToPusher tests, bind tests', ()=>{
         subscribeToPusherClient('stub');
         expect(bindSpy).toHaveBeenCalled();
     })
+
+    test('first argument to  PusherClient.bind should be "incoming_friend_requests"', ()=>{
+        subscribeToPusherClient('stub');
+        expect(bindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
+    })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -8,6 +8,8 @@ jest.mock("@/lib/pusher",()=>({
 describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
+    const request = {senderId:'foo', senderEmail:'bar'}
+
     beforeEach(()=>{
         jest.resetAllMocks();
         subscribeSpy = jest.fn();
@@ -16,19 +18,19 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     })
 
     test('calling function should call PusherClient.subscribe', ()=>{
-        const client = new PusherClientHandler('stub', jest.fn)
+        const client = new PusherClientHandler('stub', request, jest.fn)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalled();
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('12345', jest.fn)
+        const client = new PusherClientHandler('12345',request, jest.fn)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321', jest.fn)
+        const client = new PusherClientHandler('54321', request, jest.fn)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
@@ -38,6 +40,8 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
 describe('subscribeToPusher tests, bind tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
+    const request = {senderId:'foo', senderEmail:'bar'}
+
     beforeEach(()=>{
         jest.resetAllMocks();
         subscribeSpy = jest.fn();
@@ -46,19 +50,19 @@ describe('subscribeToPusher tests, bind tests', ()=>{
     })
 
     test('calling function should call PusherClient.bind', ()=>{
-        const client = new PusherClientHandler('stub', jest.fn)
+        const client = new PusherClientHandler('stub', request, jest.fn)
         client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalled();
     })
 
     test('first argument to  PusherClient.bind should be "incoming_friend_requests"', ()=>{
-        const client = new PusherClientHandler('stub', jest.fn)
+        const client = new PusherClientHandler('stub', request, jest.fn)
         client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
     })
 
     test('second argument to  PusherClient.bind should be the method friendRequestHandler', ()=>{
-        const client = new PusherClientHandler('stub')
+        const client = new PusherClientHandler('stub', request, jest.fn)
         client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalledWith(expect.anything(), client.friendRequestHandler);
     })
@@ -67,6 +71,7 @@ describe('subscribeToPusher tests, bind tests', ()=>{
 describe('subscribeToPusher tests, return value tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
+    const request = {senderId:'foo', senderEmail:'bar'}
     beforeEach(()=>{
         jest.resetAllMocks();
         subscribeSpy = jest.fn();
@@ -74,7 +79,7 @@ describe('subscribeToPusher tests, return value tests', ()=>{
         (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
     })
     test('the function returns the teardown method, which is a callable hook', ()=>{
-        const client = new PusherClientHandler('stub', jest.fn)
+        const client = new PusherClientHandler('stub', request, jest.fn)
         const actual = client.subscribeToPusherClient()
         expect(actual).toBe(client.tearDown)
     })
@@ -83,6 +88,7 @@ describe('subscribeToPusher tests, return value tests', ()=>{
 describe('tearDown tests, unsubscribe and unbind', ()=>{
     let unSubscribeSpy: jest.SpyInstance;
     let unBindSpy: jest.SpyInstance;
+    const request = {senderId:'foo', senderEmail:'bar'}
     beforeEach(()=>{
         jest.resetAllMocks();
         unSubscribeSpy = jest.fn();
@@ -91,18 +97,18 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('12345', jest.fn)
+        const client = new PusherClientHandler('12345', request, jest.fn)
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321', jest.fn)
+        const client = new PusherClientHandler('54321', request, jest.fn)
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321', jest.fn)
+        const client = new PusherClientHandler('54321', request, jest.fn)
         client.tearDown()
         expect(unBindSpy).toHaveBeenCalledWith('incoming_friend_requests');
     })
@@ -111,14 +117,14 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
 describe('friendRequestHandler tests', ()=>{
     test('the setter should be called with concatenation of the existing state and the new values', ()=>{
         const setterSpy = jest.fn();
-        const client = new PusherClientHandler('stub', setterSpy);
+        const client = new PusherClientHandler('stub',{senderId:'foo', senderEmail:'bar'}, setterSpy);
         client.friendRequestHandler()
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'}]);
     })
 
     test('the setter should be called with concatenation of the existing state and the new values', ()=>{
         const setterSpy = jest.fn();
-        const client = new PusherClientHandler('stub', setterSpy);
+        const client = new PusherClientHandler('stub',{senderId:'frasier', senderEmail:'imlistening@kacl.com'}, setterSpy);
         client.friendRequestHandler()
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
     })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -112,28 +112,25 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
 
 describe('friendRequestHandler tests', ()=>{
     test('the setter should be called with concatenation of the existing state and the new values', ()=>{
-        const setterSpy = jest.fn();
-        const state = { setFriendRequests: setterSpy, existingFriendRequests: [] };
-        const client = new PusherClientHandler('stub', state);
+        const setterSpy = jest.fn()
+        const client = new PusherClientHandler('stub', []);
         const fn = client.friendRequestHandler(setterSpy)
         fn({senderId:'foo', senderEmail:'bar'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'}]);
     })
 
     test('the setter should be called with concatenation of the existing state and the new values, different data', ()=>{
-        const setterSpy = jest.fn();
-        const state = { setFriendRequests: setterSpy, existingFriendRequests: [] };
-        const client = new PusherClientHandler('stub', state);
+        const setterSpy = jest.fn()
+        const client = new PusherClientHandler('stub', []);
         const fn = client.friendRequestHandler(setterSpy)
         fn({senderId:'frasier', senderEmail:'imlistening@kacl.com'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
     })
 
     test('the setter should be called with concatenation of the existing state and the new values', ()=>{
-        const setterSpy = jest.fn();
+        const setterSpy = jest.fn()
         const prev = [{senderId:'foo', senderEmail:'bar'}];
-        const state = { setFriendRequests: setterSpy, existingFriendRequests: prev };
-        const client = new PusherClientHandler('stub', state);
+        const client = new PusherClientHandler('stub', prev);
         const fn = client.friendRequestHandler(setterSpy)
         fn({senderId:'frasier', senderEmail:'imlistening@kacl.com'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'},

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -101,4 +101,9 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
+    test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
+        const client = new PusherClientHandler('54321')
+        client.tearDown()
+        expect(unBindSpy).toHaveBeenCalledWith('incoming_friend_requests');
+    })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -6,15 +6,17 @@ jest.mock("@/lib/pusher",()=>({
 }));
 
 describe('subscribeToPusherClient tests', ()=>{
-    test('calling function should call PusherClient.subscribe', ()=>{
-        const subscribeSpy = jest.fn();
+    let subscribeSpy: jest.SpyInstance;
+    beforeEach(()=>{
+        jest.resetAllMocks();
+        subscribeSpy = jest.fn();
         (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
+    })
+    test('calling function should call PusherClient.subscribe', ()=>{
         subscribeToPusherClient();
         expect(subscribeSpy).toHaveBeenCalled();
     })
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const subscribeSpy = jest.fn();
-        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
         subscribeToPusherClient();
         expect(subscribeSpy).toHaveBeenCalledWith('user:12345:incoming_friend_requests');
     })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -8,7 +8,6 @@ jest.mock("@/lib/pusher",()=>({
 describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
-    const state = {setFriendRequests: jest.fn, existingFriendRequests:[]}
 
     beforeEach(()=>{
         jest.resetAllMocks();
@@ -18,20 +17,20 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     })
 
     test('calling function should call PusherClient.subscribe', ()=>{
-        const client = new PusherClientHandler('stub',  state)
-        client.subscribeToPusherClient()
+        const client = new PusherClientHandler('stub',  [])
+        client.subscribeToPusherClient(jest.fn())
         expect(subscribeSpy).toHaveBeenCalled();
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('12345', state)
-        client.subscribeToPusherClient()
+        const client = new PusherClientHandler('12345', [])
+        client.subscribeToPusherClient(jest.fn())
         expect(subscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321', state)
-        client.subscribeToPusherClient()
+        const client = new PusherClientHandler('54321', [])
+        client.subscribeToPusherClient(jest.fn())
         expect(subscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
 
@@ -40,7 +39,6 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
 describe('subscribeToPusher tests, bind tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
-    const state = {setFriendRequests: jest.fn, existingFriendRequests:[]}
 
     beforeEach(()=>{
         jest.resetAllMocks();
@@ -50,13 +48,13 @@ describe('subscribeToPusher tests, bind tests', ()=>{
     })
 
     test('calling function should call PusherClient.bind', ()=>{
-        const client = new PusherClientHandler('stub', state)
+        const client = new PusherClientHandler('stub', [])
         client.subscribeToPusherClient(jest.fn)
         expect(bindSpy).toHaveBeenCalled();
     })
 
     test('first argument to  PusherClient.bind should be "incoming_friend_requests"', ()=>{
-        const client = new PusherClientHandler('stub', state)
+        const client = new PusherClientHandler('stub', [])
         client.subscribeToPusherClient(jest.fn)
         expect(bindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
     })
@@ -83,7 +81,6 @@ describe('subscribeToPusher tests, return value tests', ()=>{
 describe('tearDown tests, unsubscribe and unbind', ()=>{
     let unSubscribeSpy: jest.SpyInstance;
     let unBindSpy: jest.SpyInstance;
-    const state = {setFriendRequests: jest.fn, existingFriendRequests:[]}
 
     beforeEach(()=>{
         jest.resetAllMocks();
@@ -93,18 +90,18 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('12345', state)
+        const client = new PusherClientHandler('12345', [])
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321',  state)
+        const client = new PusherClientHandler('54321',  [])
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321',  state)
+        const client = new PusherClientHandler('54321',  [])
         client.tearDown()
         expect(unBindSpy).toHaveBeenCalledWith('incoming_friend_requests');
     })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -122,10 +122,19 @@ describe('friendRequestHandler tests', ()=>{
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'}]);
     })
 
-    test('the setter should be called with concatenation of the existing state and the new values', ()=>{
+    test('the setter should be called with concatenation of the existing state and the new values, different data', ()=>{
         const setterSpy = jest.fn();
         const client = new PusherClientHandler('stub',{senderId:'frasier', senderEmail:'imlistening@kacl.com'}, setterSpy);
         client.friendRequestHandler()
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
+    })
+
+    test('the setter should be called with concatenation of the existing state and the new values', ()=>{
+        const setterSpy = jest.fn();
+        const prev = [{senderId:'foo', senderEmail:'bar'}];
+        const client = new PusherClientHandler('stub',{senderId:'frasier', senderEmail:'imlistening@kacl.com'}, setterSpy);
+        client.friendRequestHandler()
+        expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'},
+            {senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -14,17 +14,17 @@ describe('subscribeToPusherClient tests', ()=>{
     })
 
     test('calling function should call PusherClient.subscribe', ()=>{
-        subscribeToPusherClient();
+        subscribeToPusherClient('stub');
         expect(subscribeSpy).toHaveBeenCalled();
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        subscribeToPusherClient();
+        subscribeToPusherClient('12345');
         expect(subscribeSpy).toHaveBeenCalledWith('user:12345:incoming_friend_requests');
     })
 
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
-        subscribeToPusherClient();
+        subscribeToPusherClient('54321');
         expect(subscribeSpy).toHaveBeenCalledWith('user:54321:incoming_friend_requests');
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -1,4 +1,4 @@
-import subscribeToPusherClient from "@/components/FriendRequests/helpers";
+import subscribeToPusherClient, {friendRequestHandler} from "@/components/FriendRequests/helpers";
 import {getPusherClient} from "@/lib/pusher";
 
 jest.mock("@/lib/pusher",()=>({
@@ -50,5 +50,10 @@ describe('subscribeToPusher tests, bind tests', ()=>{
     test('first argument to  PusherClient.bind should be "incoming_friend_requests"', ()=>{
         subscribeToPusherClient('stub');
         expect(bindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
+    })
+
+    test('second argument to  PusherClient.bind should be the method friendRequestHandler', ()=>{
+        subscribeToPusherClient('stub');
+        expect(bindSpy).toHaveBeenCalledWith(expect.anything, friendRequestHandler);
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -1,5 +1,6 @@
 import {getPusherClient} from "@/lib/pusher";
 import PusherClientHandler from "@/components/FriendRequests/helpers";
+import {Channel} from "pusher-js";
 
 jest.mock("@/lib/pusher",()=>({
     getPusherClient: jest.fn()
@@ -11,9 +12,9 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
 
     beforeEach(()=>{
         jest.resetAllMocks();
-        subscribeSpy = jest.fn();
         bindSpy = jest.fn();
-        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
+        subscribeSpy = jest.fn(()=> {return { bind: bindSpy}});
+        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
     })
 
     test('calling function should call PusherClient.subscribe', ()=>{
@@ -42,9 +43,9 @@ describe('subscribeToPusher tests, bind tests', ()=>{
 
     beforeEach(()=>{
         jest.resetAllMocks();
-        subscribeSpy = jest.fn();
         bindSpy = jest.fn();
-        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
+        subscribeSpy = jest.fn(()=> {return { bind: bindSpy}});
+        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
     })
 
     test('calling function should call PusherClient.bind', ()=>{
@@ -63,18 +64,19 @@ describe('subscribeToPusher tests, bind tests', ()=>{
 describe('subscribeToPusher tests, return value tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
-    const state = {setFriendRequests: jest.fn, existingFriendRequests:[]}
 
     beforeEach(()=>{
         jest.resetAllMocks();
-        subscribeSpy = jest.fn();
         bindSpy = jest.fn();
-        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
+        subscribeSpy = jest.fn(()=> {return { bind: bindSpy}});
+        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
     })
-    test('the function returns the teardown method, which is a callable hook', ()=>{
-        const client = new PusherClientHandler('stub', state)
+    test('the function returns the output of teardown metho. That return valueis a callable hook', ()=>{
+        const client = new PusherClientHandler('stub', [])
+        function expected(){}
+        jest.spyOn(client, 'tearDown').mockReturnValue(expected)
         const actual = client.subscribeToPusherClient(jest.fn)
-        expect(actual).toBe(client.tearDown)
+        expect(actual).toBe(expected)
     })
 })
 
@@ -84,25 +86,28 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
 
     beforeEach(()=>{
         jest.resetAllMocks();
-        unSubscribeSpy = jest.fn();
         unBindSpy = jest.fn();
-        (getPusherClient as jest.Mock).mockReturnValue({unsubscribe: unSubscribeSpy, unbind: unBindSpy});
+        unSubscribeSpy = jest.fn(()=> {return { unbind: unBindSpy}});
+        (getPusherClient as jest.Mock).mockReturnValue({unsubscribe: unSubscribeSpy});
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
         const client = new PusherClientHandler('12345', [])
-        client.tearDown()
+        const func =  client.tearDown({unbind: unBindSpy} as unknown as Channel)
+        func()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
         const client = new PusherClientHandler('54321',  [])
-        client.tearDown()
+        const func =  client.tearDown({unbind: unBindSpy} as unknown as Channel)
+        func()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
         const client = new PusherClientHandler('54321',  [])
-        client.tearDown()
+        const func =  client.tearDown({unbind: unBindSpy} as unknown as Channel)
+        func()
         expect(unBindSpy).toHaveBeenCalledWith('incoming_friend_requests');
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -132,7 +132,7 @@ describe('friendRequestHandler tests', ()=>{
     test('the setter should be called with concatenation of the existing state and the new values', ()=>{
         const setterSpy = jest.fn();
         const prev = [{senderId:'foo', senderEmail:'bar'}];
-        const client = new PusherClientHandler('stub',{senderId:'frasier', senderEmail:'imlistening@kacl.com'}, setterSpy);
+        const client = new PusherClientHandler('stub',{senderId:'frasier', senderEmail:'imlistening@kacl.com'}, setterSpy, prev);
         client.friendRequestHandler()
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'},
             {senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -16,19 +16,19 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     })
 
     test('calling function should call PusherClient.subscribe', ()=>{
-        const client = new PusherClientHandler('stub')
+        const client = new PusherClientHandler('stub', jest.fn)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalled();
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('12345')
+        const client = new PusherClientHandler('12345', jest.fn)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321')
+        const client = new PusherClientHandler('54321', jest.fn)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
@@ -46,13 +46,13 @@ describe('subscribeToPusher tests, bind tests', ()=>{
     })
 
     test('calling function should call PusherClient.bind', ()=>{
-        const client = new PusherClientHandler('stub')
+        const client = new PusherClientHandler('stub', jest.fn)
         client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalled();
     })
 
     test('first argument to  PusherClient.bind should be "incoming_friend_requests"', ()=>{
-        const client = new PusherClientHandler('stub')
+        const client = new PusherClientHandler('stub', jest.fn)
         client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
     })
@@ -74,7 +74,7 @@ describe('subscribeToPusher tests, return value tests', ()=>{
         (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
     })
     test('the function returns the teardown method, which is a callable hook', ()=>{
-        const client = new PusherClientHandler('stub')
+        const client = new PusherClientHandler('stub', jest.fn)
         const actual = client.subscribeToPusherClient()
         expect(actual).toBe(client.tearDown)
     })
@@ -91,18 +91,18 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('12345')
+        const client = new PusherClientHandler('12345', jest.fn)
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321')
+        const client = new PusherClientHandler('54321', jest.fn)
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321')
+        const client = new PusherClientHandler('54321', jest.fn)
         client.tearDown()
         expect(unBindSpy).toHaveBeenCalledWith('incoming_friend_requests');
     })
@@ -111,7 +111,7 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
 describe('friendRequestHandler tests', ()=>{
     test('the setter should be called with concatenation of the existing state and the new values', ()=>{
         const setterSpy = jest.fn();
-        const client = new PusherClientHandler('stub')
+        const client = new PusherClientHandler('stub', setterSpy);
         client.friendRequestHandler()
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'}]);
     })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -51,20 +51,14 @@ describe('subscribeToPusher tests, bind tests', ()=>{
 
     test('calling function should call PusherClient.bind', ()=>{
         const client = new PusherClientHandler('stub', state)
-        client.subscribeToPusherClient()
+        client.subscribeToPusherClient(jest.fn)
         expect(bindSpy).toHaveBeenCalled();
     })
 
     test('first argument to  PusherClient.bind should be "incoming_friend_requests"', ()=>{
         const client = new PusherClientHandler('stub', state)
-        client.subscribeToPusherClient()
+        client.subscribeToPusherClient(jest.fn)
         expect(bindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
-    })
-
-    test('second argument to  PusherClient.bind should be the method friendRequestHandler', ()=>{
-        const client = new PusherClientHandler('stub', state)
-        client.subscribeToPusherClient()
-        expect(bindSpy).toHaveBeenCalledWith(expect.anything(), client.friendRequestHandler);
     })
 })
 
@@ -81,7 +75,7 @@ describe('subscribeToPusher tests, return value tests', ()=>{
     })
     test('the function returns the teardown method, which is a callable hook', ()=>{
         const client = new PusherClientHandler('stub', state)
-        const actual = client.subscribeToPusherClient()
+        const actual = client.subscribeToPusherClient(jest.fn)
         expect(actual).toBe(client.tearDown)
     })
 })
@@ -121,7 +115,8 @@ describe('friendRequestHandler tests', ()=>{
         const setterSpy = jest.fn();
         const state = { setFriendRequests: setterSpy, existingFriendRequests: [] };
         const client = new PusherClientHandler('stub', state);
-        client.friendRequestHandler({senderId:'foo', senderEmail:'bar'})
+        const fn = client.friendRequestHandler(setterSpy)
+        fn({senderId:'foo', senderEmail:'bar'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'}]);
     })
 
@@ -129,7 +124,8 @@ describe('friendRequestHandler tests', ()=>{
         const setterSpy = jest.fn();
         const state = { setFriendRequests: setterSpy, existingFriendRequests: [] };
         const client = new PusherClientHandler('stub', state);
-        client.friendRequestHandler({senderId:'frasier', senderEmail:'imlistening@kacl.com'})
+        const fn = client.friendRequestHandler(setterSpy)
+        fn({senderId:'frasier', senderEmail:'imlistening@kacl.com'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
     })
 
@@ -138,7 +134,8 @@ describe('friendRequestHandler tests', ()=>{
         const prev = [{senderId:'foo', senderEmail:'bar'}];
         const state = { setFriendRequests: setterSpy, existingFriendRequests: prev };
         const client = new PusherClientHandler('stub', state);
-        client.friendRequestHandler({senderId:'frasier', senderEmail:'imlistening@kacl.com'})
+        const fn = client.friendRequestHandler(setterSpy)
+        fn({senderId:'frasier', senderEmail:'imlistening@kacl.com'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'},
             {senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
     })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -63,3 +63,19 @@ describe('subscribeToPusher tests, bind tests', ()=>{
         expect(bindSpy).toHaveBeenCalledWith(expect.anything(), client.friendRequestHandler);
     })
 })
+
+describe('subscribeToPusher tests, return value tests', ()=>{
+    let subscribeSpy: jest.SpyInstance;
+    let bindSpy: jest.SpyInstance;
+    beforeEach(()=>{
+        jest.resetAllMocks();
+        subscribeSpy = jest.fn();
+        bindSpy = jest.fn();
+        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
+    })
+    test('the function returns the teardown method, which is a callable hook', ()=>{
+        const client = new PusherClientHandler('stub')
+        const actual = client.subscribeToPusherClient()
+        expect(actual).toBe(client.tearDown)
+    })
+})

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -7,10 +7,12 @@ jest.mock("@/lib/pusher",()=>({
 
 describe('subscribeToPusherClient tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
+    let bindSpy: jest.SpyInstance;
     beforeEach(()=>{
         jest.resetAllMocks();
         subscribeSpy = jest.fn();
-        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
+        bindSpy = jest.fn();
+        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
     })
 
     test('calling function should call PusherClient.subscribe', ()=>{
@@ -26,5 +28,10 @@ describe('subscribeToPusherClient tests', ()=>{
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
         subscribeToPusherClient('54321');
         expect(subscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
+    })
+
+    test('calling function should call PusherClient.bind', ()=>{
+        subscribeToPusherClient('stub');
+        expect(bindSpy).toHaveBeenCalled();
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -20,11 +20,11 @@ describe('subscribeToPusherClient tests', ()=>{
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
         subscribeToPusherClient('12345');
-        expect(subscribeSpy).toHaveBeenCalledWith('user:12345:incoming_friend_requests');
+        expect(subscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
         subscribeToPusherClient('54321');
-        expect(subscribeSpy).toHaveBeenCalledWith('user:54321:incoming_friend_requests');
+        expect(subscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -1,5 +1,6 @@
 import subscribeToPusherClient from "@/components/FriendRequests/helpers";
 import {getPusherClient} from "@/lib/pusher";
+
 jest.mock("@/lib/pusher",()=>({
     getPusherClient: jest.fn()
 }));
@@ -8,7 +9,7 @@ describe('subscribeToPusherClient tests', ()=>{
     test('calling function should call PusherClient.subscribe', ()=>{
         const subscribeSpy = jest.fn();
         (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
-        subscribeToPusherClient()
+        subscribeToPusherClient();
         expect(subscribeSpy).toHaveBeenCalled();
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -1,5 +1,5 @@
-import subscribeToPusherClient, {friendRequestHandler} from "@/components/FriendRequests/helpers";
 import {getPusherClient} from "@/lib/pusher";
+import PusherClientHandler from "@/components/FriendRequests/helpers";
 
 jest.mock("@/lib/pusher",()=>({
     getPusherClient: jest.fn()
@@ -16,17 +16,20 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     })
 
     test('calling function should call PusherClient.subscribe', ()=>{
-        subscribeToPusherClient('stub');
+        const client = new PusherClientHandler('stub')
+        client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalled();
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        subscribeToPusherClient('12345');
+        const client = new PusherClientHandler('12345')
+        client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
-        subscribeToPusherClient('54321');
+        const client = new PusherClientHandler('54321')
+        client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
 
@@ -43,17 +46,20 @@ describe('subscribeToPusher tests, bind tests', ()=>{
     })
 
     test('calling function should call PusherClient.bind', ()=>{
-        subscribeToPusherClient('stub');
+        const client = new PusherClientHandler('stub')
+        client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalled();
     })
 
     test('first argument to  PusherClient.bind should be "incoming_friend_requests"', ()=>{
-        subscribeToPusherClient('stub');
+        const client = new PusherClientHandler('stub')
+        client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
     })
 
     test('second argument to  PusherClient.bind should be the method friendRequestHandler', ()=>{
-        subscribeToPusherClient('stub');
-        expect(bindSpy).toHaveBeenCalledWith(expect.anything(), friendRequestHandler);
+        const client = new PusherClientHandler('stub')
+        client.subscribeToPusherClient()
+        expect(bindSpy).toHaveBeenCalledWith(expect.anything(), client.friendRequestHandler);
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -89,11 +89,13 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
         unBindSpy = jest.fn();
         (getPusherClient as jest.Mock).mockReturnValue({unsubscribe: unSubscribeSpy, unbind: unBindSpy});
     })
+
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
         const client = new PusherClientHandler('12345')
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
+
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
         const client = new PusherClientHandler('54321')
         client.tearDown()

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -12,4 +12,10 @@ describe('subscribeToPusherClient tests', ()=>{
         subscribeToPusherClient();
         expect(subscribeSpy).toHaveBeenCalled();
     })
+    test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
+        const subscribeSpy = jest.fn();
+        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
+        subscribeToPusherClient();
+        expect(subscribeSpy).toHaveBeenCalledWith('user:12345:incoming_friend_requests');
+    })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -107,3 +107,12 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
         expect(unBindSpy).toHaveBeenCalledWith('incoming_friend_requests');
     })
 })
+
+describe('friendRequestHandler tests', ()=>{
+    test('the setter should be called with concatenation of the existing state and the new values', ()=>{
+        const setterSpy = jest.fn();
+        const client = new PusherClientHandler('stub')
+        client.friendRequestHandler()
+        expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'}]);
+    })
+})

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -5,7 +5,7 @@ jest.mock("@/lib/pusher",()=>({
     getPusherClient: jest.fn()
 }));
 
-describe('subscribeToPusherClient tests', ()=>{
+describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
     beforeEach(()=>{
@@ -28,6 +28,18 @@ describe('subscribeToPusherClient tests', ()=>{
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
         subscribeToPusherClient('54321');
         expect(subscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
+    })
+
+})
+
+describe('subscribeToPusher tests, bind tests', ()=>{
+    let subscribeSpy: jest.SpyInstance;
+    let bindSpy: jest.SpyInstance;
+    beforeEach(()=>{
+        jest.resetAllMocks();
+        subscribeSpy = jest.fn();
+        bindSpy = jest.fn();
+        (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
     })
 
     test('calling function should call PusherClient.bind', ()=>{

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -79,3 +79,24 @@ describe('subscribeToPusher tests, return value tests', ()=>{
         expect(actual).toBe(client.tearDown)
     })
 })
+
+describe('tearDown tests, unsubscribe and unbind', ()=>{
+    let unSubscribeSpy: jest.SpyInstance;
+    let unBindSpy: jest.SpyInstance;
+    beforeEach(()=>{
+        jest.resetAllMocks();
+        unSubscribeSpy = jest.fn();
+        unBindSpy = jest.fn();
+        (getPusherClient as jest.Mock).mockReturnValue({unsubscribe: unSubscribeSpy, unbind: unBindSpy});
+    })
+    test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
+        const client = new PusherClientHandler('12345')
+        client.tearDown()
+        expect(unSubscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
+    })
+    test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
+        const client = new PusherClientHandler('54321')
+        client.tearDown()
+        expect(unSubscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
+    })
+})

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -115,4 +115,11 @@ describe('friendRequestHandler tests', ()=>{
         client.friendRequestHandler()
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'}]);
     })
+
+    test('the setter should be called with concatenation of the existing state and the new values', ()=>{
+        const setterSpy = jest.fn();
+        const client = new PusherClientHandler('stub', setterSpy);
+        client.friendRequestHandler()
+        expect(setterSpy).toHaveBeenCalledWith([{senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
+    })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -8,7 +8,7 @@ jest.mock("@/lib/pusher",()=>({
 describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
-    const request = {senderId:'foo', senderEmail:'bar'}
+    const state = {setFriendRequests: jest.fn, existingFriendRequests:[]}
 
     beforeEach(()=>{
         jest.resetAllMocks();
@@ -18,19 +18,19 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
     })
 
     test('calling function should call PusherClient.subscribe', ()=>{
-        const client = new PusherClientHandler('stub', request, jest.fn)
+        const client = new PusherClientHandler('stub',  state)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalled();
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('12345',request, jest.fn)
+        const client = new PusherClientHandler('12345', state)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321', request, jest.fn)
+        const client = new PusherClientHandler('54321', state)
         client.subscribeToPusherClient()
         expect(subscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
@@ -40,7 +40,7 @@ describe('subscribeToPusherClient tests, subscribe tests', ()=>{
 describe('subscribeToPusher tests, bind tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
-    const request = {senderId:'foo', senderEmail:'bar'}
+    const state = {setFriendRequests: jest.fn, existingFriendRequests:[]}
 
     beforeEach(()=>{
         jest.resetAllMocks();
@@ -50,19 +50,19 @@ describe('subscribeToPusher tests, bind tests', ()=>{
     })
 
     test('calling function should call PusherClient.bind', ()=>{
-        const client = new PusherClientHandler('stub', request, jest.fn)
+        const client = new PusherClientHandler('stub', state)
         client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalled();
     })
 
     test('first argument to  PusherClient.bind should be "incoming_friend_requests"', ()=>{
-        const client = new PusherClientHandler('stub', request, jest.fn)
+        const client = new PusherClientHandler('stub', state)
         client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
     })
 
     test('second argument to  PusherClient.bind should be the method friendRequestHandler', ()=>{
-        const client = new PusherClientHandler('stub', request, jest.fn)
+        const client = new PusherClientHandler('stub', state)
         client.subscribeToPusherClient()
         expect(bindSpy).toHaveBeenCalledWith(expect.anything(), client.friendRequestHandler);
     })
@@ -71,7 +71,8 @@ describe('subscribeToPusher tests, bind tests', ()=>{
 describe('subscribeToPusher tests, return value tests', ()=>{
     let subscribeSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
-    const request = {senderId:'foo', senderEmail:'bar'}
+    const state = {setFriendRequests: jest.fn, existingFriendRequests:[]}
+
     beforeEach(()=>{
         jest.resetAllMocks();
         subscribeSpy = jest.fn();
@@ -79,7 +80,7 @@ describe('subscribeToPusher tests, return value tests', ()=>{
         (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, bind: bindSpy});
     })
     test('the function returns the teardown method, which is a callable hook', ()=>{
-        const client = new PusherClientHandler('stub', request, jest.fn)
+        const client = new PusherClientHandler('stub', state)
         const actual = client.subscribeToPusherClient()
         expect(actual).toBe(client.tearDown)
     })
@@ -88,7 +89,8 @@ describe('subscribeToPusher tests, return value tests', ()=>{
 describe('tearDown tests, unsubscribe and unbind', ()=>{
     let unSubscribeSpy: jest.SpyInstance;
     let unBindSpy: jest.SpyInstance;
-    const request = {senderId:'foo', senderEmail:'bar'}
+    const state = {setFriendRequests: jest.fn, existingFriendRequests:[]}
+
     beforeEach(()=>{
         jest.resetAllMocks();
         unSubscribeSpy = jest.fn();
@@ -97,18 +99,18 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
     })
 
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('12345', request, jest.fn)
+        const client = new PusherClientHandler('12345', state)
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
     })
 
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321', request, jest.fn)
+        const client = new PusherClientHandler('54321',  state)
         client.tearDown()
         expect(unSubscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
     test('if the sessionID is 54321, then subscribe is called with user:12345:incoming_friend_requests',()=>{
-        const client = new PusherClientHandler('54321', request, jest.fn)
+        const client = new PusherClientHandler('54321',  state)
         client.tearDown()
         expect(unBindSpy).toHaveBeenCalledWith('incoming_friend_requests');
     })
@@ -117,23 +119,26 @@ describe('tearDown tests, unsubscribe and unbind', ()=>{
 describe('friendRequestHandler tests', ()=>{
     test('the setter should be called with concatenation of the existing state and the new values', ()=>{
         const setterSpy = jest.fn();
-        const client = new PusherClientHandler('stub',{senderId:'foo', senderEmail:'bar'}, setterSpy);
-        client.friendRequestHandler()
+        const state = { setFriendRequests: setterSpy, existingFriendRequests: [] };
+        const client = new PusherClientHandler('stub', state);
+        client.friendRequestHandler({senderId:'foo', senderEmail:'bar'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'}]);
     })
 
     test('the setter should be called with concatenation of the existing state and the new values, different data', ()=>{
         const setterSpy = jest.fn();
-        const client = new PusherClientHandler('stub',{senderId:'frasier', senderEmail:'imlistening@kacl.com'}, setterSpy);
-        client.friendRequestHandler()
+        const state = { setFriendRequests: setterSpy, existingFriendRequests: [] };
+        const client = new PusherClientHandler('stub', state);
+        client.friendRequestHandler({senderId:'frasier', senderEmail:'imlistening@kacl.com'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
     })
 
     test('the setter should be called with concatenation of the existing state and the new values', ()=>{
         const setterSpy = jest.fn();
         const prev = [{senderId:'foo', senderEmail:'bar'}];
-        const client = new PusherClientHandler('stub',{senderId:'frasier', senderEmail:'imlistening@kacl.com'}, setterSpy, prev);
-        client.friendRequestHandler()
+        const state = { setFriendRequests: setterSpy, existingFriendRequests: prev };
+        const client = new PusherClientHandler('stub', state);
+        client.friendRequestHandler({senderId:'frasier', senderEmail:'imlistening@kacl.com'})
         expect(setterSpy).toHaveBeenCalledWith([{senderId:'foo', senderEmail:'bar'},
             {senderId:'frasier', senderEmail:'imlistening@kacl.com'}]);
     })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -12,12 +12,19 @@ describe('subscribeToPusherClient tests', ()=>{
         subscribeSpy = jest.fn();
         (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy});
     })
+
     test('calling function should call PusherClient.subscribe', ()=>{
         subscribeToPusherClient();
         expect(subscribeSpy).toHaveBeenCalled();
     })
+
     test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
         subscribeToPusherClient();
         expect(subscribeSpy).toHaveBeenCalledWith('user:12345:incoming_friend_requests');
+    })
+
+    test('if the sessionID is 54321 , then subscribe is called with user:54321:incoming_friend_requests',()=>{
+        subscribeToPusherClient();
+        expect(subscribeSpy).toHaveBeenCalledWith('user:54321:incoming_friend_requests');
     })
 })

--- a/__tests__/components/FriendRequests/helpers.test.ts
+++ b/__tests__/components/FriendRequests/helpers.test.ts
@@ -54,6 +54,6 @@ describe('subscribeToPusher tests, bind tests', ()=>{
 
     test('second argument to  PusherClient.bind should be the method friendRequestHandler', ()=>{
         subscribeToPusherClient('stub');
-        expect(bindSpy).toHaveBeenCalledWith(expect.anything, friendRequestHandler);
+        expect(bindSpy).toHaveBeenCalledWith(expect.anything(), friendRequestHandler);
     })
 })

--- a/__tests__/lib/pusher.test.ts
+++ b/__tests__/lib/pusher.test.ts
@@ -86,17 +86,17 @@ function testClientKey(pusherKey:string){
 }
 
 function testServerAppId(id:string){
-    process.env.PUSHER_APP_ID = id
+    process.env.NEXT_PUBLIC_PUSHER_APP_ID = id
     expectServerContainting({appId:id})
 }
 
 function testServerKey(pusherKey:string){
-    process.env.PUSHER_KEY = pusherKey
+    process.env.NEXT_PUBLIC_PUSHER_CLIENT_KEY = pusherKey
     expectServerContainting({key:pusherKey})
 }
 
 function testServerAppSecret(secret:string){
-    process.env.PUSHER_SECRET =secret
+    process.env.NEXT_PUBLIC_PUSHER_CLIENT_SECRET =secret
     expectServerContainting({secret:secret})
 }
 

--- a/__tests__/lib/pusher.test.ts
+++ b/__tests__/lib/pusher.test.ts
@@ -41,11 +41,11 @@ describe('pusher server creation tests', () => {
     })
 
     test('make sure pusher server is called with US-3 cluster', ()=>{
-        expectServerContainting({cluster:'us3'})
+        expectServerContaining({cluster:'us3'})
     })
 
     test('make sure pusher server is called with useTLS:true', ()=>{
-        expectServerContainting({useTLS:true})
+        expectServerContaining({useTLS:true})
     })
 })
 
@@ -87,20 +87,20 @@ function testClientKey(pusherKey:string){
 
 function testServerAppId(id:string){
     process.env.NEXT_PUBLIC_PUSHER_APP_ID = id
-    expectServerContainting({appId:id})
+    expectServerContaining({appId:id})
 }
 
 function testServerKey(pusherKey:string){
     process.env.NEXT_PUBLIC_PUSHER_CLIENT_KEY = pusherKey
-    expectServerContainting({key:pusherKey})
+    expectServerContaining({key:pusherKey})
 }
 
 function testServerAppSecret(secret:string){
     process.env.NEXT_PUBLIC_PUSHER_SECRET = secret
-    expectServerContainting({secret:secret})
+    expectServerContaining({secret:secret})
 }
 
-function expectServerContainting(prop: object){
+function expectServerContaining(prop: object){
     getPusherServer()
     expect(PusherServer).toHaveBeenCalledWith(expect.objectContaining(prop))
 }

--- a/__tests__/lib/pusher.test.ts
+++ b/__tests__/lib/pusher.test.ts
@@ -80,7 +80,7 @@ describe('pusher client creation tests', ()=>{
 })
 
 function testClientKey(pusherKey:string){
-    process.env.PUSHER_KEY = pusherKey
+    process.env.NEXT_PUBLIC_PUSHER_CLIENT_KEY = pusherKey
     getPusherClient()
     expect(PusherClient).toHaveBeenCalledWith(pusherKey, expect.anything())
 }

--- a/__tests__/lib/pusher.test.ts
+++ b/__tests__/lib/pusher.test.ts
@@ -96,7 +96,7 @@ function testServerKey(pusherKey:string){
 }
 
 function testServerAppSecret(secret:string){
-    process.env.NEXT_PUBLIC_PUSHER_CLIENT_SECRET =secret
+    process.env.NEXT_PUBLIC_PUSHER_SECRET = secret
     expectServerContainting({secret:secret})
 }
 

--- a/src/app/(dashboard)/dashboard/requests/page.tsx
+++ b/src/app/(dashboard)/dashboard/requests/page.tsx
@@ -12,13 +12,14 @@ const Page: FC = async () =>{
         return null;
     }
 
-    const requests = await getFriendRequests(session.user.id);
+    const sessionId = session.user.id
+    const requests = await getFriendRequests(sessionId);
     return <main className='pt-8'>
         <h1>
             Friend Requests
         </h1>
         <div className='friend-requests-wrapper'>
-            <FriendRequests incomingFriendRequests={requests}/>
+            <FriendRequests incomingFriendRequests={requests} sessionId={sessionId}/>
         </div>
     </main>
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -11,6 +11,7 @@ interface errorProps{
         status: number
     }
 }
+
 export class PostFriendsRouteHandler {
     private status: number
     private message: string
@@ -114,13 +115,15 @@ export class PostFriendsRouteHandler {
         return session;
     }
 
-
-
-    triggerPusherServer(id:string = this.idToAdd){
+    triggerPusherServer(id:string = this.idToAdd, data: dataProps = {senderId: this.senderId}){
         const pusherServer = getPusherServer();
         const channel = QueryBuilder.incomingFriendRequestsPusher(id);
         const event = QueryBuilder.incoming_friend_requests
-        pusherServer.trigger(channel, event, {senderId: 'mork'});
+        pusherServer.trigger(channel, event, data);
     }
+}
+
+interface dataProps {
+    senderId: string;
 }
 

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -115,7 +115,9 @@ export class PostFriendsRouteHandler {
         return session;
     }
 
-    triggerPusherServer(id:string = this.idToAdd, data: dataProps = {senderId: this.senderId}){
+    triggerPusherServer(id:string = this.idToAdd,
+                        data: dataProps = {senderId: this.senderId, senderEmail: this.senderEmail}){
+
         const pusherServer = getPusherServer();
         const channel = QueryBuilder.incomingFriendRequestsPusher(id);
         const event = QueryBuilder.incoming_friend_requests
@@ -125,5 +127,6 @@ export class PostFriendsRouteHandler {
 
 interface dataProps {
     senderId: string;
+    senderEmail: string;
 }
 

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -129,4 +129,3 @@ interface dataProps {
     senderId: string;
     senderEmail: string;
 }
-

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -116,6 +116,8 @@ export class PostFriendsRouteHandler {
 
     triggerPusherServer( id:string = this.senderId){
         const pusherServer = getPusherServer();
-        pusherServer.trigger(QueryBuilder.incomingFriendRequestsPusher(id), QueryBuilder.incoming_friend_requests, 'stub');
+        const channel = QueryBuilder.incomingFriendRequestsPusher(id);
+        const event = QueryBuilder.incoming_friend_requests
+        pusherServer.trigger(channel, event, 'stub');
     }
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -115,7 +115,7 @@ export class PostFriendsRouteHandler {
         return session;
     }
 
-    triggerPusherServer(id:string = this.idToAdd,
+    async triggerPusherServer(id:string = this.idToAdd,
                         data: dataProps = {senderId: this.senderId, senderEmail: this.senderEmail}){
 
         const pusherServer = getPusherServer();

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -3,6 +3,7 @@ import myGetServerSession from "@/lib/myGetServerSession";
 import fetchRedis from "@/helpers/redis";
 import {db} from "@/lib/db";
 import QueryBuilder from "@/lib/queryBuilder";
+import {getPusherServer} from "@/lib/pusher";
 
 interface errorProps{
     message: string,
@@ -108,5 +109,8 @@ export class PostFriendsRouteHandler {
         return session
     }
 
-    triggerPusherServer(){}
+    triggerPusherServer(){
+        const pusherServer = getPusherServer()
+        pusherServer.trigger('stub', 'stub', 'stub')
+    }
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -114,8 +114,8 @@ export class PostFriendsRouteHandler {
         return session;
     }
 
-    triggerPusherServer(){
+    triggerPusherServer( id:string = this.senderId){
         const pusherServer = getPusherServer();
-        pusherServer.trigger('user__1235__friend_requests', 'stub', 'stub');
+        pusherServer.trigger('user__'+id+'__friend_requests', 'stub', 'stub');
     }
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -120,7 +120,7 @@ export class PostFriendsRouteHandler {
         const pusherServer = getPusherServer();
         const channel = QueryBuilder.incomingFriendRequestsPusher(id);
         const event = QueryBuilder.incoming_friend_requests
-        pusherServer.trigger(channel, event, 'stub');
+        pusherServer.trigger(channel, event, {senderId: 'mork'});
     }
 }
 

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -111,6 +111,6 @@ export class PostFriendsRouteHandler {
 
     triggerPusherServer(){
         const pusherServer = getPusherServer()
-        pusherServer.trigger('stub', 'stub', 'stub')
+        pusherServer.trigger('user__1235__friend_requests', 'stub', 'stub')
     }
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -120,7 +120,7 @@ export class PostFriendsRouteHandler {
 
         const pusherServer = getPusherServer();
         const channel = QueryBuilder.incomingFriendRequestsPusher(id);
-        const event = QueryBuilder.incoming_friend_requests
+        const event = QueryBuilder.incoming_friend_requests;
         pusherServer.trigger(channel, event, data);
     }
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -116,6 +116,6 @@ export class PostFriendsRouteHandler {
 
     triggerPusherServer( id:string = this.senderId){
         const pusherServer = getPusherServer();
-        pusherServer.trigger('user__'+id+'__friend_requests', 'stub', 'stub');
+        pusherServer.trigger(QueryBuilder.incomingFriendRequestsPusher(id), 'stub', 'stub');
     }
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -117,11 +117,10 @@ export class PostFriendsRouteHandler {
 
     async triggerPusherServer(id:string = this.idToAdd,
                         data: dataProps = {senderId: this.senderId, senderEmail: this.senderEmail}){
-
         const pusherServer = getPusherServer();
         const channel = QueryBuilder.incomingFriendRequestsPusher(id);
         const event = QueryBuilder.incoming_friend_requests;
-        pusherServer.trigger(channel, event, data);
+        await pusherServer.trigger(channel, event, data);
     }
 }
 

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -116,6 +116,6 @@ export class PostFriendsRouteHandler {
 
     triggerPusherServer( id:string = this.senderId){
         const pusherServer = getPusherServer();
-        pusherServer.trigger(QueryBuilder.incomingFriendRequestsPusher(id), 'stub', 'stub');
+        pusherServer.trigger(QueryBuilder.incomingFriendRequestsPusher(id), QueryBuilder.incoming_friend_requests, 'stub');
     }
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -107,4 +107,6 @@ export class PostFriendsRouteHandler {
         this.senderEmail= session?.user?.email as string
         return session
     }
+
+    triggerPusherServer(){}
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -25,92 +25,97 @@ export class PostFriendsRouteHandler {
     }
 
     validateEmail(email:{email:string}){
-        return addFriendValidator.parse(email.email)
+        return addFriendValidator.parse(email.email);
     }
 
     setAndReturn(message: string, status: number = 400): boolean{
-        this.status = status
-        this.message = message
-        return false
+        this.status = status;
+        this.message = message;
+        return false;
     }
 
     async isValidRequest(email:{email:string}):Promise<boolean>{
         try{
             email= this.validateEmail(email)
-        }catch(error){
-            console.error({error})
-            return this.setAndReturn('Invalid request payload', 422)
+        }catch{
+            return this.setAndReturn('Invalid request payload', 422);
         }
-        const userExists = await this.userExists(email.email)
+
+        const userExists = await this.userExists(email.email);
+
         if (!userExists){
-            return this.setAndReturn('This person does not exist.')
+            return this.setAndReturn('This person does not exist.');
         }
 
-        const session = await this.getSession()
+        const session = await this.getSession();
+
         if (!session){
-            return this.setAndReturn('unauthorized', 401)
+            return this.setAndReturn('unauthorized', 401);
         }
 
-        const isSameUser = this.isSameUser()
+        const isSameUser = this.isSameUser();
+
         if (isSameUser){
-            return this.setAndReturn('You cannot add yourself as a friend')
+            return this.setAndReturn('You cannot add yourself as a friend');
         }
 
-        const isAlreadyAdded = await this.isAlreadyAdded()
+        const isAlreadyAdded = await this.isAlreadyAdded();
+
         if (isAlreadyAdded){
-            return this.setAndReturn('You\'ve already added this user')
+            return this.setAndReturn('You\'ve already added this user');
         }
 
-        const areAlreadyFriends = await this.areAlreadyFriends()
+        const areAlreadyFriends = await this.areAlreadyFriends();
+
         if (areAlreadyFriends){
-            return this.setAndReturn("You're already friends with this user")
+            return this.setAndReturn("You're already friends with this user");
         }
 
-        return true
+        return true;
     }
 
     async userExists(email:string):Promise<boolean>{
-        this.idToAdd = await fetchRedis("get",QueryBuilder.email(email))
-        return Boolean(this.idToAdd)
+        this.idToAdd = await fetchRedis("get",QueryBuilder.email(email));
+        return Boolean(this.idToAdd);
     }
 
     async redisSismember(userId: string, list: 'incoming_friend_requests' | 'friends', queryId:string):Promise<boolean>{
-        const result = await fetchRedis("sismember",  QueryBuilder.join(userId, list), queryId) as 0 | 1
-        return Boolean(result)
+        const result = await fetchRedis("sismember",  QueryBuilder.join(userId, list), queryId) as 0 | 1;
+        return Boolean(result);
     }
 
     async isAlreadyAdded():Promise<boolean>{
-        return this.redisSismember(this.idToAdd, 'incoming_friend_requests', this.senderId)
+        return this.redisSismember(this.idToAdd, 'incoming_friend_requests', this.senderId);
     }
 
     async areAlreadyFriends():Promise<boolean>{
-        return this.redisSismember(this.senderId, 'friends',this.idToAdd)
+        return this.redisSismember(this.senderId, 'friends',this.idToAdd);
     }
 
     async addToDB():Promise<void>{
-        await db.sadd(QueryBuilder.incomingFriendRequests(this.idToAdd),this.senderId )
+        await db.sadd(QueryBuilder.incomingFriendRequests(this.idToAdd),this.senderId);
     }
 
     isSameUser():boolean{
-        return this.senderId === this.idToAdd
+        return this.senderId === this.idToAdd;
     }
 
     errorResponse(): errorProps{
         return  {
             message:this.message,
             opts: { status: this.status }
-        }
+        };
     }
 
     async getSession(){
-        const session = await myGetServerSession()
-        this.senderId = session?.user?.id as string
-        this.senderEmail= session?.user?.email as string
-        return session
+        const session = await myGetServerSession();
+        this.senderId = session?.user?.id as string;
+        this.senderEmail= session?.user?.email as string;
+        return session;
     }
 
     triggerPusherServer(){
-        const pusherServer = getPusherServer()
-        pusherServer.trigger('user__1235__friend_requests', 'stub', 'stub')
+        const pusherServer = getPusherServer();
+        pusherServer.trigger('user__1235__friend_requests', 'stub', 'stub');
     }
 }

--- a/src/app/api/friends/add/handler.ts
+++ b/src/app/api/friends/add/handler.ts
@@ -114,10 +114,13 @@ export class PostFriendsRouteHandler {
         return session;
     }
 
-    triggerPusherServer( id:string = this.senderId){
+
+
+    triggerPusherServer(id:string = this.idToAdd){
         const pusherServer = getPusherServer();
         const channel = QueryBuilder.incomingFriendRequestsPusher(id);
         const event = QueryBuilder.incoming_friend_requests
         pusherServer.trigger(channel, event, 'stub');
     }
 }
+

--- a/src/app/api/friends/add/route.ts
+++ b/src/app/api/friends/add/route.ts
@@ -11,6 +11,7 @@ export async function  POST(req: Request):Promise<Response> {
         const {message, opts} = routeHandler.errorResponse()
         return new Response(message, opts)
     }
+
     routeHandler.triggerPusherServer()
     await routeHandler.addToDB()
     return new Response('OK')

--- a/src/app/api/friends/add/route.ts
+++ b/src/app/api/friends/add/route.ts
@@ -12,7 +12,7 @@ export async function  POST(req: Request):Promise<Response> {
         return new Response(message, opts)
     }
 
-    routeHandler.triggerPusherServer()
+    await routeHandler.triggerPusherServer()
     await routeHandler.addToDB()
     return new Response('OK')
 

--- a/src/app/api/friends/add/route.ts
+++ b/src/app/api/friends/add/route.ts
@@ -2,7 +2,6 @@ import {PostFriendsRouteHandler} from "@/app/api/friends/add/handler";
 
 
 export async function  POST(req: Request):Promise<Response> {
-
     const routeHandler = new PostFriendsRouteHandler()
     const body = await req.json()
     const validRequest = await routeHandler.isValidRequest({email: body.email})
@@ -15,5 +14,4 @@ export async function  POST(req: Request):Promise<Response> {
     await routeHandler.triggerPusherServer()
     await routeHandler.addToDB()
     return new Response('OK')
-
 }

--- a/src/app/api/friends/add/route.ts
+++ b/src/app/api/friends/add/route.ts
@@ -11,7 +11,7 @@ export async function  POST(req: Request):Promise<Response> {
         const {message, opts} = routeHandler.errorResponse()
         return new Response(message, opts)
     }
-
+    routeHandler.triggerPusherServer()
     await routeHandler.addToDB()
     return new Response('OK')
 

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -5,6 +5,7 @@ import {Check, UserPlus, X} from 'lucide-react';
 import axios from "axios";
 import { useRouter } from 'next/navigation';
 import subscribeToPusherClient from "@/components/FriendRequests/helpers"
+import PusherClientHandler from "@/components/FriendRequests/helpers";
 
 interface FriendRequestsProps {
     incomingFriendRequests: FriendRequest[]
@@ -34,7 +35,9 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
         await apiPost(senderId, 'deny')
     }
 
-    useEffect(()=> subscribeToPusherClient(sessionId), []);
+    const client = new PusherClientHandler(sessionId)
+
+    useEffect(()=> client.subscribeToPusherClient, []);
 
     return <div aria-label='friend requests'>
         {incomingFriendRequests.length == 0 ?

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -32,17 +32,11 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
         await apiPost(senderId, 'deny')
     }
 
-    const state = {
-        setFriendRequests: setRequests,
-        existingFriendRequests: requests
-    }
-
-
     useEffect(()=> {
-        const client = new PusherClientHandler(sessionId, state)
+        const client = new PusherClientHandler(sessionId, requests)
         console.log('useEffect called')
         client.subscribeToPusherClient(setRequests)
-    }, [sessionId, state]);
+    }, [sessionId, requests]);
 
     return <div aria-label='friend requests'>
         {requests.length == 0 ?

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -32,7 +32,12 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
         await apiPost(senderId, 'deny')
     }
 
-    const client = new PusherClientHandler(sessionId)
+    const state = {
+        setFriendRequests: setRequests,
+        existingFriendRequests: requests
+    }
+
+    const client = new PusherClientHandler(sessionId, state)
 
     useEffect(()=> {
         console.log('useEffect called')

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -8,11 +8,12 @@ import subscribeToPusherClient from "@/components/FriendRequests/helpers"
 
 interface FriendRequestsProps {
     incomingFriendRequests: FriendRequest[]
+    sessionId: string
 }
 
 type command = 'accept' | 'deny'
 
-const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests})=>{
+const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, sessionId})=>{
     const router = useRouter()
     const [requests, setRequests] = useState<{
         senderId:string,
@@ -33,7 +34,7 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests})=>{
         await apiPost(senderId, 'deny')
     }
 
-    useEffect(subscribeToPusherClient, []);
+    useEffect(()=> subscribeToPusherClient(sessionId), []);
 
     return <div aria-label='friend requests'>
         {incomingFriendRequests.length == 0 ?

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -36,7 +36,10 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
 
     const client = new PusherClientHandler(sessionId)
 
-    useEffect(()=> client.subscribeToPusherClient(), []);
+    useEffect(()=> {
+        console.log('useEffect called')
+        client.subscribeToPusherClient()
+    }, []);
 
     return <div aria-label='friend requests'>
         {incomingFriendRequests.length == 0 ?

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -37,12 +37,16 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
         client.subscribeToPusherClient(setRequests)
     }, [sessionId, requests]);
 
+    if (requests.length ==0){
+        return <div aria-label='friend requests'>
+            <p className='friend-requests-nothing'>
+                Nothing to show here...
+            </p>
+        </div>
+    }
+
     return <div aria-label='friend requests'>
-        {requests.length == 0 ?
-        <p className='friend-requests-nothing'>
-            Nothing to show here...
-        </p>:
-            requests.map((request)=>{
+        {requests.map((request)=>{
                 return (<div className='friend-requests' key={request.senderId}>
                     <UserPlus  aria-label='add user'/>
                     <p className='friend-requests-email'>
@@ -65,8 +69,7 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
                         />
                     </button>
                 </div>)
-            })
-        }</div>
+            })}</div>
 }
 
 export default FriendRequests;

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -4,7 +4,6 @@ import {FC, useEffect, useState} from "react";
 import {Check, UserPlus, X} from 'lucide-react';
 import axios from "axios";
 import { useRouter } from 'next/navigation';
-import subscribeToPusherClient from "@/components/FriendRequests/helpers"
 import PusherClientHandler from "@/components/FriendRequests/helpers";
 
 interface FriendRequestsProps {
@@ -37,7 +36,7 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
 
     const client = new PusherClientHandler(sessionId)
 
-    useEffect(()=> client.subscribeToPusherClient, []);
+    useEffect(()=> client.subscribeToPusherClient(), []);
 
     return <div aria-label='friend requests'>
         {incomingFriendRequests.length == 0 ?

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -37,15 +37,15 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
         existingFriendRequests: requests
     }
 
-    const client = new PusherClientHandler(sessionId, state)
 
     useEffect(()=> {
+        const client = new PusherClientHandler(sessionId, state)
         console.log('useEffect called')
-        client.subscribeToPusherClient()
-    }, []);
+        client.subscribeToPusherClient(setRequests)
+    }, [sessionId, state]);
 
     return <div aria-label='friend requests'>
-        {incomingFriendRequests.length == 0 ?
+        {requests.length == 0 ?
         <p className='friend-requests-nothing'>
             Nothing to show here...
         </p>:

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -34,7 +34,6 @@ const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, session
 
     useEffect(()=> {
         const client = new PusherClientHandler(sessionId, requests)
-        console.log('useEffect called')
         client.subscribeToPusherClient(setRequests)
     }, [sessionId, requests]);
 

--- a/src/components/FriendRequests/FriendRequests.tsx
+++ b/src/components/FriendRequests/FriendRequests.tsx
@@ -15,10 +15,8 @@ type command = 'accept' | 'deny'
 
 const FriendRequests :FC<FriendRequestsProps> =({incomingFriendRequests, sessionId})=>{
     const router = useRouter()
-    const [requests, setRequests] = useState<{
-        senderId:string,
-        senderEmail:string
-    }[]>(incomingFriendRequests);
+    const [requests, setRequests] = useState<FriendRequest[]>(incomingFriendRequests);
+
 
     const apiPost = async (senderId: string, cmd: command) =>{
         await axios.post(`/api/friends/${cmd}`, {id: senderId});

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -11,8 +11,8 @@ export default class PusherClientHandler{
     constructor(sessionId:string){
         this._sessionId = sessionId
         this._pusherClient = getPusherClient()
-        this._subscribeQuery = QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__')
-        this._bindField = 'incoming_friend_requests'
+        this._subscribeQuery = QueryBuilder.incomingFriendRequestsPusher(this._sessionId)
+        this._bindField = QueryBuilder.incoming_friend_requests
     }
 
     subscribeToPusherClient (){

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -10,14 +10,16 @@ export default class PusherClientHandler{
     private readonly _bindField: string;
     private readonly _setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>;
     private readonly _currentRequest: FriendRequest
+    private readonly _existingFriendRequests: FriendRequest[]
 
-    constructor(sessionId:string, currentRequest: FriendRequest, setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>){
+    constructor(sessionId:string, currentRequest: FriendRequest, setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>, existingFriendRequests: FriendRequest[] = []){
         this._sessionId = sessionId
         this._pusherClient = getPusherClient()
         this._subscribeQuery = QueryBuilder.incomingFriendRequestsPusher(this._sessionId)
         this._bindField = QueryBuilder.incoming_friend_requests
         this._setFriendRequests = setFriendRequests
         this._currentRequest = currentRequest
+        this._existingFriendRequests = existingFriendRequests
     }
 
     subscribeToPusherClient (){
@@ -27,7 +29,7 @@ export default class PusherClientHandler{
     }
 
     friendRequestHandler(){
-        this._setFriendRequests([this._currentRequest])
+        this._setFriendRequests([ ... this._existingFriendRequests, this._currentRequest])
     }
 
     tearDown(){

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -2,5 +2,5 @@ import {getPusherClient} from "@/lib/pusher";
 
 export default function subscribeToPusherClient (sessionId: string){
     const pusherClient = getPusherClient();
-    pusherClient.subscribe(`user:${sessionId}:incoming_friend_requests`);
+    pusherClient.subscribe(`user__${sessionId}__incoming_friend_requests`);
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -1,23 +1,27 @@
 import {getPusherClient} from "@/lib/pusher";
 import QueryBuilder from "@/lib/queryBuilder";
+import PusherClient from "pusher-js";
 
 
 
 export default class PusherClientHandler{
     private readonly _sessionId: string
+    private _pusherClient: PusherClient;
 
     constructor(sessionId:string){
         this._sessionId = sessionId
+        this._pusherClient = getPusherClient()
     }
 
     subscribeToPusherClient (){
-        const pusherClient = getPusherClient();
-        pusherClient.subscribe(QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__'));
-        pusherClient.bind('incoming_friend_requests', this.friendRequestHandler)
+        this._pusherClient.subscribe(QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__'));
+        this._pusherClient.bind('incoming_friend_requests', this.friendRequestHandler)
         return this.tearDown
     }
 
     friendRequestHandler(){}
 
-    tearDown(){}
+    tearDown(){
+        this._pusherClient.unsubscribe(QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__'));
+    }
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -1,10 +1,19 @@
 import {getPusherClient} from "@/lib/pusher";
 import QueryBuilder from "@/lib/queryBuilder";
 
-export default function subscribeToPusherClient (sessionId: string){
-    const pusherClient = getPusherClient();
-    pusherClient.subscribe(QueryBuilder.incomingFriendRequests(sessionId).replace(/:/g, '__'));
-    pusherClient.bind('incoming_friend_requests', friendRequestHandler)
-}
 
-export function friendRequestHandler(){}
+
+export default class PusherClientHandler{
+    private readonly _sessionId: string
+
+    constructor(sessionId:string){
+        this._sessionId = sessionId
+    }
+
+    subscribeToPusherClient (){
+        const pusherClient = getPusherClient();
+        pusherClient.subscribe(QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__'));
+        pusherClient.bind('incoming_friend_requests', this.friendRequestHandler)
+    }
+    friendRequestHandler(){}
+}

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -9,13 +9,15 @@ export default class PusherClientHandler{
     private readonly _subscribeQuery: string;
     private readonly _bindField: string;
     private readonly _setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>;
+    private readonly _currentRequest: FriendRequest
 
-    constructor(sessionId:string, setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>){
+    constructor(sessionId:string, currentRequest: FriendRequest, setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>){
         this._sessionId = sessionId
         this._pusherClient = getPusherClient()
         this._subscribeQuery = QueryBuilder.incomingFriendRequestsPusher(this._sessionId)
         this._bindField = QueryBuilder.incoming_friend_requests
         this._setFriendRequests = setFriendRequests
+        this._currentRequest = currentRequest
     }
 
     subscribeToPusherClient (){
@@ -25,7 +27,7 @@ export default class PusherClientHandler{
     }
 
     friendRequestHandler(){
-        this._setFriendRequests([{senderId:'foo', senderEmail:'bar'}])
+        this._setFriendRequests([this._currentRequest])
     }
 
     tearDown(){

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -1,6 +1,6 @@
 import {getPusherClient} from "@/lib/pusher";
 
 export default function subscribeToPusherClient (){
-    const pusherClient = getPusherClient()
-    pusherClient.subscribe('stub')
+    const pusherClient = getPusherClient();
+    pusherClient.subscribe('stub');
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -1,18 +1,21 @@
 import {getPusherClient} from "@/lib/pusher";
 import QueryBuilder from "@/lib/queryBuilder";
 import PusherClient from "pusher-js";
+import {Dispatch, SetStateAction} from "react";
 
 export default class PusherClientHandler{
     private readonly _sessionId: string
     private _pusherClient: PusherClient;
     private readonly _subscribeQuery: string;
     private readonly _bindField: string;
+    private _setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>;
 
-    constructor(sessionId:string){
+    constructor(sessionId:string, setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>){
         this._sessionId = sessionId
         this._pusherClient = getPusherClient()
         this._subscribeQuery = QueryBuilder.incomingFriendRequestsPusher(this._sessionId)
         this._bindField = QueryBuilder.incoming_friend_requests
+        this._setFriendRequests = setFriendRequests
     }
 
     subscribeToPusherClient (){
@@ -21,7 +24,9 @@ export default class PusherClientHandler{
         return this.tearDown
     }
 
-    friendRequestHandler(){}
+    friendRequestHandler(){
+        this._setFriendRequests([{senderId:'foo', senderEmail:'bar'}])
+    }
 
     tearDown(){
         this._pusherClient.unsubscribe(this._subscribeQuery);

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -4,7 +4,7 @@ import QueryBuilder from "@/lib/queryBuilder";
 export default function subscribeToPusherClient (sessionId: string){
     const pusherClient = getPusherClient();
     pusherClient.subscribe(QueryBuilder.incomingFriendRequests(sessionId).replace(/:/g, '__'));
-    pusherClient.bind('incoming_friend_requests', ()=>{})
+    pusherClient.bind('incoming_friend_requests', friendRequestHandler)
 }
 
 export function friendRequestHandler(){}

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -23,5 +23,6 @@ export default class PusherClientHandler{
 
     tearDown(){
         this._pusherClient.unsubscribe(this._subscribeQuery);
+        this._pusherClient.unbind('incoming_friend_requests');
     }
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -7,14 +7,16 @@ import PusherClient from "pusher-js";
 export default class PusherClientHandler{
     private readonly _sessionId: string
     private _pusherClient: PusherClient;
+    private readonly _subscribeQuery: string;
 
     constructor(sessionId:string){
         this._sessionId = sessionId
         this._pusherClient = getPusherClient()
+        this._subscribeQuery = QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__')
     }
 
     subscribeToPusherClient (){
-        this._pusherClient.subscribe(QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__'));
+        this._pusherClient.subscribe(this._subscribeQuery);
         this._pusherClient.bind('incoming_friend_requests', this.friendRequestHandler)
         return this.tearDown
     }
@@ -22,6 +24,6 @@ export default class PusherClientHandler{
     friendRequestHandler(){}
 
     tearDown(){
-        this._pusherClient.unsubscribe(QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__'));
+        this._pusherClient.unsubscribe(this._subscribeQuery);
     }
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -1,40 +1,41 @@
 import {getPusherClient} from "@/lib/pusher";
 import QueryBuilder from "@/lib/queryBuilder";
-import PusherClient from "pusher-js";
+import PusherClient, { Channel } from "pusher-js";
 import {Dispatch, SetStateAction} from "react";
 
-export default class PusherClientHandler{
-    private readonly _sessionId: string
+export default class PusherClientHandler {
+    private readonly _sessionId: string;
     private _pusherClient: PusherClient;
     private readonly _subscribeQuery: string;
     private readonly _bindField: string;
-    private readonly _existingFriendRequests: FriendRequest[]
+    private readonly _existingFriendRequests: FriendRequest[];
 
-    constructor(sessionId:string,  existingFriendRequests: FriendRequest[]){
-        this._sessionId = sessionId
-        this._pusherClient = getPusherClient()
-        this._subscribeQuery = QueryBuilder.incomingFriendRequestsPusher(this._sessionId)
-        this._bindField = QueryBuilder.incoming_friend_requests
-        this._existingFriendRequests = existingFriendRequests
+    constructor(sessionId: string, existingFriendRequests: FriendRequest[]) {
+        this._sessionId = sessionId;
+        this._pusherClient = getPusherClient();
+        this._subscribeQuery = QueryBuilder.incomingFriendRequestsPusher(this._sessionId);
+        this._bindField = QueryBuilder.incoming_friend_requests;
+        this._existingFriendRequests = existingFriendRequests;
     }
 
-    subscribeToPusherClient (f: Dispatch<SetStateAction<FriendRequest[]>>){
-        this._pusherClient.subscribe(this._subscribeQuery);
-        this._pusherClient.bind(this._bindField, this.friendRequestHandler(f))
-        return this.tearDown
+    subscribeToPusherClient(f: Dispatch<SetStateAction<FriendRequest[]>>) {
+        const channel = this._pusherClient.subscribe(this._subscribeQuery);
+        channel.bind(this._bindField, this.friendRequestHandler(f));
+
+        return this.tearDown(channel);
     }
 
-    friendRequestHandler(f: Dispatch<SetStateAction<FriendRequest[]>>){
-        console.log(f)
-        console.log(typeof f)
-       return (request: FriendRequest)=>{
-               f([ ... this._existingFriendRequests, request])
-       }
+    friendRequestHandler(func: Dispatch<SetStateAction<FriendRequest[]>>) {
+        return (request: FriendRequest) => {
+            func([...this._existingFriendRequests, request]);
+        };
 
     }
 
-    tearDown(){
-        this._pusherClient.unsubscribe(this._subscribeQuery);
-        this._pusherClient.unbind(this._bindField);
+    tearDown(channel: Channel){
+        return ()=>{
+            channel.unbind(this._bindField);
+            this._pusherClient.unsubscribe(this._subscribeQuery);
+        }
     }
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -4,4 +4,5 @@ import QueryBuilder from "@/lib/queryBuilder";
 export default function subscribeToPusherClient (sessionId: string){
     const pusherClient = getPusherClient();
     pusherClient.subscribe(QueryBuilder.incomingFriendRequests(sessionId).replace(/:/g, '__'));
+    pusherClient.bind('stub', ()=>{})
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -1,6 +1,6 @@
 import {getPusherClient} from "@/lib/pusher";
 
-export default function subscribeToPusherClient (){
+export default function subscribeToPusherClient (sessionId: string){
     const pusherClient = getPusherClient();
-    pusherClient.subscribe('user:12345:incoming_friend_requests');
+    pusherClient.subscribe(`user:${sessionId}:incoming_friend_requests`);
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -4,5 +4,5 @@ import QueryBuilder from "@/lib/queryBuilder";
 export default function subscribeToPusherClient (sessionId: string){
     const pusherClient = getPusherClient();
     pusherClient.subscribe(QueryBuilder.incomingFriendRequests(sessionId).replace(/:/g, '__'));
-    pusherClient.bind('stub', ()=>{})
+    pusherClient.bind('incoming_friend_requests', ()=>{})
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -1,6 +1,7 @@
 import {getPusherClient} from "@/lib/pusher";
+import QueryBuilder from "@/lib/queryBuilder";
 
 export default function subscribeToPusherClient (sessionId: string){
     const pusherClient = getPusherClient();
-    pusherClient.subscribe(`user__${sessionId}__incoming_friend_requests`);
+    pusherClient.subscribe(QueryBuilder.incomingFriendRequests(sessionId).replace(/:/g, '__'));
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -8,7 +8,7 @@ export default class PusherClientHandler{
     private _pusherClient: PusherClient;
     private readonly _subscribeQuery: string;
     private readonly _bindField: string;
-    private _setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>;
+    private readonly _setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>;
 
     constructor(sessionId:string, setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>){
         this._sessionId = sessionId

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -2,8 +2,6 @@ import {getPusherClient} from "@/lib/pusher";
 import QueryBuilder from "@/lib/queryBuilder";
 import PusherClient from "pusher-js";
 
-
-
 export default class PusherClientHandler{
     private readonly _sessionId: string
     private _pusherClient: PusherClient;

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -14,6 +14,7 @@ export default class PusherClientHandler{
         const pusherClient = getPusherClient();
         pusherClient.subscribe(QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__'));
         pusherClient.bind('incoming_friend_requests', this.friendRequestHandler)
+        return this.tearDown
     }
 
     friendRequestHandler(){}

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -2,5 +2,5 @@ import {getPusherClient} from "@/lib/pusher";
 
 export default function subscribeToPusherClient (){
     const pusherClient = getPusherClient();
-    pusherClient.subscribe('stub');
+    pusherClient.subscribe('user:12345:incoming_friend_requests');
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -25,14 +25,17 @@ export default class PusherClientHandler{
         this._existingFriendRequests = requestState.existingFriendRequests
     }
 
-    subscribeToPusherClient (){
+    subscribeToPusherClient (f: Dispatch<SetStateAction<FriendRequest[]>>){
         this._pusherClient.subscribe(this._subscribeQuery);
-        this._pusherClient.bind(this._bindField, this.friendRequestHandler)
+        this._pusherClient.bind(this._bindField, this.friendRequestHandler(f))
         return this.tearDown
     }
 
-    friendRequestHandler(request: FriendRequest){
-        this._setFriendRequests([ ... this._existingFriendRequests, request])
+    friendRequestHandler(f: Dispatch<SetStateAction<FriendRequest[]>>){
+       return (request: FriendRequest)=>{
+               f([ ... this._existingFriendRequests, request])
+       }
+
     }
 
     tearDown(){

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -15,5 +15,8 @@ export default class PusherClientHandler{
         pusherClient.subscribe(QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__'));
         pusherClient.bind('incoming_friend_requests', this.friendRequestHandler)
     }
+
     friendRequestHandler(){}
+
+    tearDown(){}
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -3,26 +3,19 @@ import QueryBuilder from "@/lib/queryBuilder";
 import PusherClient from "pusher-js";
 import {Dispatch, SetStateAction} from "react";
 
-interface State {
-    setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>,
-    existingFriendRequests: FriendRequest[]
-}
-
 export default class PusherClientHandler{
     private readonly _sessionId: string
     private _pusherClient: PusherClient;
     private readonly _subscribeQuery: string;
     private readonly _bindField: string;
-    private readonly _setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>;
     private readonly _existingFriendRequests: FriendRequest[]
 
-    constructor(sessionId:string, requestState: State){
+    constructor(sessionId:string,  existingFriendRequests: FriendRequest[]){
         this._sessionId = sessionId
         this._pusherClient = getPusherClient()
         this._subscribeQuery = QueryBuilder.incomingFriendRequestsPusher(this._sessionId)
         this._bindField = QueryBuilder.incoming_friend_requests
-        this._setFriendRequests = requestState.setFriendRequests
-        this._existingFriendRequests = requestState.existingFriendRequests
+        this._existingFriendRequests = existingFriendRequests
     }
 
     subscribeToPusherClient (f: Dispatch<SetStateAction<FriendRequest[]>>){
@@ -32,6 +25,8 @@ export default class PusherClientHandler{
     }
 
     friendRequestHandler(f: Dispatch<SetStateAction<FriendRequest[]>>){
+        console.log(f)
+        console.log(typeof f)
        return (request: FriendRequest)=>{
                f([ ... this._existingFriendRequests, request])
        }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -6,16 +6,18 @@ export default class PusherClientHandler{
     private readonly _sessionId: string
     private _pusherClient: PusherClient;
     private readonly _subscribeQuery: string;
+    private readonly _bindField: string;
 
     constructor(sessionId:string){
         this._sessionId = sessionId
         this._pusherClient = getPusherClient()
         this._subscribeQuery = QueryBuilder.incomingFriendRequests(this._sessionId).replace(/:/g, '__')
+        this._bindField = 'incoming_friend_requests'
     }
 
     subscribeToPusherClient (){
         this._pusherClient.subscribe(this._subscribeQuery);
-        this._pusherClient.bind('incoming_friend_requests', this.friendRequestHandler)
+        this._pusherClient.bind(this._bindField, this.friendRequestHandler)
         return this.tearDown
     }
 
@@ -23,6 +25,6 @@ export default class PusherClientHandler{
 
     tearDown(){
         this._pusherClient.unsubscribe(this._subscribeQuery);
-        this._pusherClient.unbind('incoming_friend_requests');
+        this._pusherClient.unbind(this._bindField);
     }
 }

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -6,3 +6,5 @@ export default function subscribeToPusherClient (sessionId: string){
     pusherClient.subscribe(QueryBuilder.incomingFriendRequests(sessionId).replace(/:/g, '__'));
     pusherClient.bind('incoming_friend_requests', ()=>{})
 }
+
+export function friendRequestHandler(){}

--- a/src/components/FriendRequests/helpers.ts
+++ b/src/components/FriendRequests/helpers.ts
@@ -3,23 +3,26 @@ import QueryBuilder from "@/lib/queryBuilder";
 import PusherClient from "pusher-js";
 import {Dispatch, SetStateAction} from "react";
 
+interface State {
+    setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>,
+    existingFriendRequests: FriendRequest[]
+}
+
 export default class PusherClientHandler{
     private readonly _sessionId: string
     private _pusherClient: PusherClient;
     private readonly _subscribeQuery: string;
     private readonly _bindField: string;
     private readonly _setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>;
-    private readonly _currentRequest: FriendRequest
     private readonly _existingFriendRequests: FriendRequest[]
 
-    constructor(sessionId:string, currentRequest: FriendRequest, setFriendRequests: Dispatch<SetStateAction<FriendRequest[]>>, existingFriendRequests: FriendRequest[] = []){
+    constructor(sessionId:string, requestState: State){
         this._sessionId = sessionId
         this._pusherClient = getPusherClient()
         this._subscribeQuery = QueryBuilder.incomingFriendRequestsPusher(this._sessionId)
         this._bindField = QueryBuilder.incoming_friend_requests
-        this._setFriendRequests = setFriendRequests
-        this._currentRequest = currentRequest
-        this._existingFriendRequests = existingFriendRequests
+        this._setFriendRequests = requestState.setFriendRequests
+        this._existingFriendRequests = requestState.existingFriendRequests
     }
 
     subscribeToPusherClient (){
@@ -28,8 +31,8 @@ export default class PusherClientHandler{
         return this.tearDown
     }
 
-    friendRequestHandler(){
-        this._setFriendRequests([ ... this._existingFriendRequests, this._currentRequest])
+    friendRequestHandler(request: FriendRequest){
+        this._setFriendRequests([ ... this._existingFriendRequests, request])
     }
 
     tearDown(){

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -14,5 +14,15 @@ export function getPusherServer(){
 }
 
 export function getPusherClient(){
-    return new PusherClient(process.env.PUSHER_KEY as string,{cluster})
+    return new PusherClient(getPusherCredentials().pusherKey, {cluster})
+}
+
+function getPusherCredentials(){
+    const pusherKey  = process.env.NEXT_PUBLIC_PUSHER_CLIENT_KEY
+
+    if (!pusherKey || pusherKey.length === 0) {
+        throw new Error('Missing NEXT_PUBLIC_PUSHER_CLIENT_KEY')
+    }
+
+    return {pusherKey}
 }

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -4,10 +4,11 @@ import PusherClient from "pusher-js";
 const cluster = 'us3'
 
 export function getPusherServer(){
+    const {appId, pusherKey, secret} = getPusherCredentials()
     return new PusherServer({
-        appId: process.env.PUSHER_APP_ID as string,
-        key: process.env.PUSHER_KEY as string,
-        secret: process.env.PUSHER_SECRET as string,
+        appId: appId,
+        key: pusherKey,
+        secret: secret,
         cluster,
         useTLS: true
     })
@@ -18,11 +19,15 @@ export function getPusherClient(){
 }
 
 function getPusherCredentials(){
-    const pusherKey  = process.env.NEXT_PUBLIC_PUSHER_CLIENT_KEY
+    const pusherKey  = process.env.NEXT_PUBLIC_PUSHER_CLIENT_KEY as string
 
-    if (!pusherKey || pusherKey.length === 0) {
-        throw new Error('Missing NEXT_PUBLIC_PUSHER_CLIENT_KEY')
-    }
 
-    return {pusherKey}
+    const appId = process.env.NEXT_PUBLIC_PUSHER_APP_ID as string
+
+
+
+    const secret =  process.env.NEXT_PUBLIC_PUSHER_SECRET as string
+
+
+    return {pusherKey, appId, secret}
 }

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -20,14 +20,7 @@ export function getPusherClient(){
 
 function getPusherCredentials(){
     const pusherKey  = process.env.NEXT_PUBLIC_PUSHER_CLIENT_KEY as string
-
-
     const appId = process.env.NEXT_PUBLIC_PUSHER_APP_ID as string
-
-
-
     const secret =  process.env.NEXT_PUBLIC_PUSHER_SECRET as string
-
-
     return {pusherKey, appId, secret}
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -21,7 +21,7 @@ export default class QueryBuilder {
     }
 
     static incomingFriendRequests(userId: string): string {
-        return this.join(userId, 'incoming_friend_requests')
+        return this.join(userId, this.incoming_friend_requests)
     }
 
     static join(userId: string, suffix: string): string {
@@ -30,5 +30,13 @@ export default class QueryBuilder {
 
     static email(email: string): string {
        return  this._append('email', email)
+    }
+
+    static incomingFriendRequestsPusher(userId: string):string {
+        return this.incomingFriendRequests(userId).replace(/:/g, '__')
+    }
+
+    static get incoming_friend_requests () {
+        return 'incoming_friend_requests'
     }
 }


### PR DESCRIPTION
The friends/add/ endpoint now sends a message to pusher which the FriendRequests endpoint subscribes to. 

The endpoint sends a message to pusher before editing the database. That message is on a channel set to friend requests including the target user's id.

FriendRequests  component. The call subscribes to a pusher channel with friend requests set to the user's ID. This is set in useEffect and uses state management to make the changes live.

The result here is the component updates live.

