### PR TITLE
Fix dashboard loading

### DIFF
--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -247,14 +247,6 @@ describe('calls to pusher',()=>{
     })
 
     test('expect pusher.trigger to be called with data of the current user', async ()=>{
-        (fetchRedis as jest.Mock).mockResolvedValueOnce(false)
-            .mockResolvedValueOnce(true)
-            .mockResolvedValueOnce({
-                name: 'Adam',
-                email: 'adam@batcave.com',
-                image: 'stub',
-                id: '1966'
-            })
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
         const req = requestFromId('54321')
@@ -267,14 +259,6 @@ describe('calls to pusher',()=>{
         });
     })
     test('expect pusher.trigger to be called with data of the current user, different data', async ()=>{
-        (fetchRedis as jest.Mock).mockResolvedValueOnce(false)
-            .mockResolvedValueOnce(true)
-            .mockResolvedValueOnce({
-            name: 'William',
-            email: 'bill@canda.ca',
-            image: 'stub',
-            id: '1701'
-        })
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
         const req = requestFromId('54321')

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -259,6 +259,18 @@ describe('calls to pusher',()=>{
             id: '1966'
         });
     })
+    test('expect pusher.trigger to be called with data of the current user, diferent data', async ()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
+        const req = requestFromId('54321')
+        await POST(req);
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+            name: 'William',
+            email: 'bill@canda.ca',
+            image: 'stub',
+            id: '1701'
+        });
+    })
 })
 
 function assertResponse( response: Response, expected: expectedResponse): void{

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -270,6 +270,7 @@ describe('calls to pusher',()=>{
             id: '1701'
         });
     })
+
     test('needs two calls: one for the user and one for the id to add', async ()=>{
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -215,12 +215,7 @@ describe('calls to pusher',()=>{
     beforeEach(() => {
         triggerSpy = jest.fn();
         (getPusherServer as jest.Mock).mockReturnValue({trigger: triggerSpy});
-        (fetchRedis as jest.Mock).mockResolvedValueOnce(false).mockResolvedValueOnce(true).mockResolvedValueOnce({
-            name: 'William',
-            email: 'bill@canda.ca',
-            image: 'stub',
-            id: '1701'
-        })
+        (fetchRedis as jest.Mock).mockImplementation(redisMock());
     })
 
     afterEach(()=>{
@@ -271,7 +266,7 @@ describe('calls to pusher',()=>{
             id: '1966'
         });
     })
-    test('expect pusher.trigger to be called with data of the current user, diferent data', async ()=>{
+    test('expect pusher.trigger to be called with data of the current user, different data', async ()=>{
         (fetchRedis as jest.Mock).mockResolvedValueOnce(false)
             .mockResolvedValueOnce(true)
             .mockResolvedValueOnce({
@@ -312,6 +307,7 @@ function requestFromId(id: string | number): Request{
 
 function redisMock(isGreen: boolean = true){
     return async ( command: string, query:string, opts:string)=>{
+        console.log(query)
         if (command == 'sismember'){
             const arr = query.split(':');
             const query_name = arr[arr.length-1];
@@ -324,15 +320,17 @@ function redisMock(isGreen: boolean = true){
                     throw new Error('invalid table');
             }
         }
-        switch(query){
-            case 'user:1966':
+        const arr = query.split(':');
+        const query_name = arr[arr.length-1];
+        switch(query_name){
+            case '1966':
                 return {
                     name: 'Adam',
                     email: 'adam@batcave.com',
                     image: 'stub',
                     id: '1966'
                 }
-            case 'user:1701':
+            case '1701':
                 return {
                     name: 'William',
                     email: 'bill@canda.ca',

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -238,6 +238,14 @@ describe('calls to pusher',()=>{
         await POST(req);
         expect(triggerSpy).toHaveBeenCalledWith("user__54321__friends", expect.anything(), expect.anything());
     })
+
+    test('id to add is 54321 expect pusher.trigger to be called with event "new_friend"', async ()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
+        const req = requestify('54321')
+        await POST(req);
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), 'new_friend', expect.anything());
+    })
 })
 
 function assertResponse( response: Response, expected: expectedResponse): void{

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -229,7 +229,15 @@ describe('calls to pusher',()=>{
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
         const req = requestify('valid')
         await POST(req);
-        expect(triggerSpy).toHaveBeenCalledWith(QueryBuilder.friendsPusher('12345'), expect.anything(), expect.anything());
+        expect(triggerSpy).toHaveBeenCalledWith("user__12345__friends", expect.anything(), expect.anything());
+    })
+
+    test('id to add is 54321 expect pusher.trigger to be called with first arg "user__12345__friends"', async ()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
+        const req = requestify('valid')
+        await POST(req);
+        expect(triggerSpy).toHaveBeenCalledWith("user__54321__friends", expect.anything(), expect.anything());
     })
 })
 

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -3,7 +3,6 @@ import myGetServerSession from "@/lib/myGetServerSession";
 import fetchRedis from "@/helpers/redis";
 import { db } from '@/lib/db';
 import { getPusherServer} from "@/lib/pusher";
-import QueryBuilder from "@/lib/queryBuilder";
 
 jest.mock("@/lib/pusher",()=>({
     getPusherServer: jest.fn()
@@ -68,7 +67,7 @@ describe('/api/friends/accept', () => {
         assertResponse(response, expected);
     });
 
-    test("If the user's session is valid, then  POST doesn't return 401 UnAuthorized", async () => {
+    test("If the user's session is valid, then  POST doesn't return 401 Unauthorized", async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
         const req = requestify('valid')
@@ -227,7 +226,7 @@ describe('calls to pusher',()=>{
     test('id to add is 12345 expect pusher.trigger to be called with first arg "user__12345__friends"', async ()=>{
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
-        const req = requestify('valid')
+        const req = requestify('12345')
         await POST(req);
         expect(triggerSpy).toHaveBeenCalledWith("user__12345__friends", expect.anything(), expect.anything());
     })
@@ -235,7 +234,7 @@ describe('calls to pusher',()=>{
     test('id to add is 54321 expect pusher.trigger to be called with first arg "user__12345__friends"', async ()=>{
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
-        const req = requestify('valid')
+        const req = requestify('54321')
         await POST(req);
         expect(triggerSpy).toHaveBeenCalledWith("user__54321__friends", expect.anything(), expect.anything());
     })

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -40,13 +40,13 @@ describe('/api/friends/accept', () => {
 
     test('If is all anticipated case, then POST runs without throwing', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
-        const req = requestify('valid')
+        const req = requestFromId('valid')
         await POST(req);
     });
 
     test('If the request value is not a string, then POST returns a 422', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
-        const req = requestify(42)
+        const req = requestFromId(42)
         const expectedResponse: expectedResponse = {
             status: 422,
             text: 'Invalid Request'
@@ -58,7 +58,7 @@ describe('/api/friends/accept', () => {
     test("If the user's session is null, then POST returns a 401", async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue(null);
-        const req = requestify('valid')
+        const req = requestFromId('valid')
         const expected: expectedResponse = {
             status:401,
             text: 'Unauthorized'
@@ -70,7 +70,7 @@ describe('/api/friends/accept', () => {
     test("If the user's session is valid, then  POST doesn't return 401 Unauthorized", async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
-        const req = requestify('valid')
+        const req = requestFromId('valid')
         const response =  await POST(req);
         const notExpected: expectedResponse = {
             status: 401,
@@ -82,7 +82,7 @@ describe('/api/friends/accept', () => {
     test('If fetchRedis"(sismember, user:1701:friends)" is truthy, then POST returns 401, Already Friends', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
-        const req = requestify('valid');
+        const req = requestFromId('valid');
         (fetchRedis as jest.Mock).mockResolvedValue(true);
 
         const response =  await POST(req);
@@ -97,7 +97,7 @@ describe('/api/friends/accept', () => {
         async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
-        const req = requestify('valid');
+        const req = requestFromId('valid');
         (fetchRedis as jest.Mock).mockResolvedValue(false);
 
         const response =  await POST(req);
@@ -111,7 +111,7 @@ describe('/api/friends/accept', () => {
     test('If POST is called by user 5468, then fetchRedis is called with second arg == "5468"', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
-        const req = requestify('5468');
+        const req = requestFromId('5468');
         await POST(req);
         expect(fetchRedis as jest.Mock).toHaveBeenCalledWith(expect.anything(),expect.anything(), '5468');
     });
@@ -119,7 +119,7 @@ describe('/api/friends/accept', () => {
     test('If POST is called with a request for 1701, then fetchRedis is called with first arg == "user:1701:friends" ', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
-        const req = requestify('5468');
+        const req = requestFromId('5468');
         await POST(req);
         expect(fetchRedis as jest.Mock).toHaveBeenCalledWith(expect.anything(),'user:1701:friends', expect.anything());
     });
@@ -127,7 +127,7 @@ describe('/api/friends/accept', () => {
     test('If POST is called , then fetchRedis is called with command == "sismember" ', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
-        const req = requestify('5468');
+        const req = requestFromId('5468');
         await POST(req);
         expect(fetchRedis as jest.Mock).toHaveBeenCalledWith("sismember",expect.anything(), expect.anything());
     });
@@ -135,7 +135,7 @@ describe('/api/friends/accept', () => {
     test('If POST is called by user 1701, then fetchRedis is be called with second arg == 1701 ', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
-        const req = requestify('1701');
+        const req = requestFromId('1701');
         await POST(req);
         expect(fetchRedis as jest.Mock).toHaveBeenCalledWith(expect.anything(),expect.anything(), '1701');
     });
@@ -143,7 +143,7 @@ describe('/api/friends/accept', () => {
     test('If POST is called with 1966 in payload, then fetchRedis should be called with first arg == user:1966:friends,', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
-        const req = requestify('1701');
+        const req = requestFromId('1701');
         await POST(req);
         expect(fetchRedis as jest.Mock).toHaveBeenCalledWith(expect.anything(),'user:1966:friends', expect.anything());
     });
@@ -157,7 +157,7 @@ describe('/api/friends/accept', () => {
             status: 400
         }
 
-        const request = requestify('1701');
+        const request = requestFromId('1701');
         const response = await POST(request);
 
         assertResponse(response, expected);
@@ -168,7 +168,7 @@ describe('/api/friends/accept', () => {
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
         (fetchRedis as jest.Mock).mockImplementation(redisMock())
 
-        const request = requestify('1701');
+        const request = requestFromId('1701');
         await POST(request);
         expect(db.sadd).toHaveBeenCalledWith('user:1966:friends', '1701');
         expect(db.sadd).toHaveBeenCalledWith('user:1701:friends', '1966');
@@ -179,7 +179,7 @@ describe('/api/friends/accept', () => {
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'8569'}});
         (fetchRedis as jest.Mock).mockImplementation(redisMock());
 
-        const request = requestify('666');
+        const request = requestFromId('666');
         await POST(request);
 
         expect(db.sadd).toHaveBeenCalledWith('user:8569:friends', '666');
@@ -191,7 +191,7 @@ describe('/api/friends/accept', () => {
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'8569'}});
         (fetchRedis as jest.Mock).mockImplementation(redisMock());
 
-        const request = requestify('666');
+        const request = requestFromId('666');
         await POST(request);
 
         expect(db.srem).toHaveBeenCalledWith('user:8569:incoming_friend_requests', '666');
@@ -203,7 +203,7 @@ describe('/api/friends/accept', () => {
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'4567'}});
         (fetchRedis as jest.Mock).mockImplementation(redisMock());
 
-        const request = requestify('7777');
+        const request = requestFromId('7777');
         await POST(request);
 
         expect(db.srem).toHaveBeenCalledWith('user:4567:incoming_friend_requests', '7777');
@@ -226,7 +226,7 @@ describe('calls to pusher',()=>{
     test('id to add is 12345 expect pusher.trigger to be called with first arg "user__12345__friends"', async ()=>{
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
-        const req = requestify('12345')
+        const req = requestFromId('12345')
         await POST(req);
         expect(triggerSpy).toHaveBeenCalledWith("user__12345__friends", expect.anything(), expect.anything());
     })
@@ -234,7 +234,7 @@ describe('calls to pusher',()=>{
     test('id to add is 54321 expect pusher.trigger to be called with first arg "user__12345__friends"', async ()=>{
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
-        const req = requestify('54321')
+        const req = requestFromId('54321')
         await POST(req);
         expect(triggerSpy).toHaveBeenCalledWith("user__54321__friends", expect.anything(), expect.anything());
     })
@@ -242,9 +242,22 @@ describe('calls to pusher',()=>{
     test('id to add is 54321 expect pusher.trigger to be called with event "new_friend"', async ()=>{
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
-        const req = requestify('54321')
+        const req = requestFromId('54321')
         await POST(req);
         expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), 'new_friend', expect.anything());
+    })
+
+    test('expect pusher.trigger to be called with data of the current user', async ()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1966'}});
+        const req = requestFromId('54321')
+        await POST(req);
+        expect(triggerSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+            name: 'Adam',
+            email: 'adam@batcave.com',
+            image: 'stub',
+            id: '1966'
+        });
     })
 })
 
@@ -257,7 +270,7 @@ function assertNotResponse( response: Response, expected: expectedResponse): voi
     expect(response.status === expected.status && response.body?.toString()== expected.text);
 }
 
-function requestify(id: string | number): Request{
+function requestFromId(id: string | number): Request{
     return new Request('/api/friends/accept', {
         method: 'POST',
         body: JSON.stringify({ id: id }),

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -257,7 +257,8 @@ describe('calls to pusher',()=>{
             image: 'stub',
             id: '1966'
         });
-    })
+    });
+
     test('expect pusher.trigger to be called with data of the current user, different data', async ()=>{
         fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
         (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});

--- a/__tests__/app/api/friends/accept/route.test.ts
+++ b/__tests__/app/api/friends/accept/route.test.ts
@@ -270,6 +270,24 @@ describe('calls to pusher',()=>{
             id: '1701'
         });
     })
+    test('needs two calls: one for the user and one for the id to add', async ()=>{
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+        (myGetServerSession as jest.Mock).mockResolvedValue({user:{id:'1701'}});
+        const req = requestFromId('1966')
+        await POST(req);
+        expect(triggerSpy).toHaveBeenCalledWith("user__1966__friends", 'new_friend', {
+            name: 'William',
+            email: 'bill@canda.ca',
+            image: 'stub',
+            id: '1701'
+        });
+        expect(triggerSpy).toHaveBeenCalledWith("user__1701__friends", 'new_friend', {
+            name: 'Adam',
+            email: 'adam@batcave.com',
+            image: 'stub',
+            id: '1966'
+        });
+    })
 })
 
 function assertResponse( response: Response, expected: expectedResponse): void{

--- a/__tests__/components/FriendRequestSidebarOptions/FriendRequestSidebarOptions.test.tsx
+++ b/__tests__/components/FriendRequestSidebarOptions/FriendRequestSidebarOptions.test.tsx
@@ -9,6 +9,8 @@ jest.mock('react', ()=>({
     useState: jest.fn()
 }));
 
+jest.mock("@/components/friendRequestSidebarOptions/helpers");
+
 jest.spyOn(PusherClientHandler.prototype, 'subscribeToPusher').mockImplementation(jest.fn());
 
 describe('FriendRequestSidebarOptions', () => {

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -68,6 +68,7 @@ describe('PusherClientHandler bind tests', () => {
         (getPusherClient as jest.Mock).mockImplementation(()=>{
             return {subscribe: subscribeSpy}
         });
+
         client = new PusherClientHandler('stub_id', 0)
     })
 
@@ -81,12 +82,12 @@ describe('PusherClientHandler bind tests', () => {
         expect(friendBindSpy).toHaveBeenCalled();
     })
 
-    test('first argument to channel.bind should be "incoming_friend_requests"', ()=>{
+    test('first argument to requestChannel.bind should be "incoming_friend_requests"', ()=>{
         client.subscribeToPusher(jest.fn())
         expect(requestBindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
     })
 
-    test('second argument to channel.bind should be the the output of  method handleRequest', ()=>{
+    test('second argument to requestsChannel.bind should be the the output of method handleRequest', ()=>{
         function expected(){}
         jest.spyOn(client, 'handleRequest').mockReturnValue(expected)
         client.subscribeToPusher(jest.fn())
@@ -98,6 +99,11 @@ describe('PusherClientHandler bind tests', () => {
         const handleSpy = jest.spyOn(client, 'handleRequest')
         client.subscribeToPusher(expected)
         expect(handleSpy).toHaveBeenCalledWith(expected);
+    })
+
+    test('first argument passed to friendsChannel.bind should be "new_friend"',()=>{
+        client.subscribeToPusher(jest.fn())
+        expect(friendBindSpy).toHaveBeenCalledWith("new_friend", expect.anything());
     })
 })
 

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -101,11 +101,18 @@ describe('PusherClientHandler bind tests', () => {
         expect(friendBindSpy).toHaveBeenCalledWith(expect.anything(), expected);
     })
 
-    test('argument from subscribeToPusher should be the same passed to handleSpy', ()=>{
+    test('argument from subscribeToPusher should be the same passed to incrementCount', ()=>{
         function expected(){}
         const incrementCountSpy = jest.spyOn(client, 'incrementCount')
         client.subscribeToPusher(expected)
         expect(incrementCountSpy).toHaveBeenCalledWith(expected);
+    })
+
+    test('argument from subscribeToPusher should be the same passed to incrementCount', ()=>{
+        function expected(){}
+        const decrementCountSpy = jest.spyOn(client, 'decrementCount')
+        client.subscribeToPusher(expected)
+        expect(decrementCountSpy).toHaveBeenCalledWith(expected);
     })
 
     test('first argument passed to friendsChannel.bind should be "new_friend"',()=>{

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -108,7 +108,7 @@ describe('PusherClientHandler bind tests', () => {
         expect(incrementCountSpy).toHaveBeenCalledWith(expected);
     })
 
-    test('argument from subscribeToPusher should be the same passed to incrementCount', ()=>{
+    test('argument from subscribeToPusher should be the same passed to decrementCount', ()=>{
         function expected(){}
         const decrementCountSpy = jest.spyOn(client, 'decrementCount')
         client.subscribeToPusher(expected)
@@ -121,7 +121,7 @@ describe('PusherClientHandler bind tests', () => {
     })
 })
 
-describe('PusherClientHandler handleRequest tests', () => {
+describe('PusherClientHandler incrementCount tests', () => {
     let client: PusherClientHandler;
     let setterSpy: jest.Mock
     beforeEach(()=>{
@@ -138,6 +138,28 @@ describe('PusherClientHandler handleRequest tests', () => {
     test('the existing count is 8, so 9 is passed to the setter',()=>{
         client = new PusherClientHandler('stub_id', 8)
         const func = client.incrementCount(setterSpy)
+        func()
+        expect(setterSpy).toHaveBeenCalledWith(9)
+    })
+})
+
+describe('PusherClientHandler decrementCount tests', () => {
+    let client: PusherClientHandler;
+    let setterSpy: jest.Mock
+    beforeEach(()=>{
+        setterSpy = jest.fn()
+    })
+
+    test('the existing count is 1, so 0 is passed to the setter',()=>{
+        client = new PusherClientHandler('stub_id', 1)
+        const func = client.decrementCount(setterSpy)
+        func()
+        expect(setterSpy).toHaveBeenCalledWith(0)
+    })
+
+    test('the existing count is 8, so 7 is passed to the setter',()=>{
+        client = new PusherClientHandler('stub_id', 7)
+        const func = client.decrementCount(setterSpy)
         func()
         expect(setterSpy).toHaveBeenCalledWith(9)
     })

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -29,6 +29,12 @@ describe('PusherClientHandler tests', () => {
         expect(subscribeSpy).toHaveBeenCalledWith('user__12345__friends');
     })
 
+    test('if the sessionID is 54321, then subscribe is called with user__54321__friends',()=>{
+        client = new PusherClientHandler('54321', 0)
+        client.subscribeToPusher(jest.fn())
+        expect(subscribeSpy).toHaveBeenCalledWith('user__54321__friends');
+    })
+
     test('if the sessionID is 12345, then subscribe is called with user__12345__incoming_friend_requests',()=>{
         client = new PusherClientHandler('12345', 0)
         client.subscribeToPusher(jest.fn())

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -87,18 +87,25 @@ describe('PusherClientHandler bind tests', () => {
         expect(requestBindSpy).toHaveBeenCalledWith("incoming_friend_requests", expect.anything());
     })
 
-    test('second argument to requestsChannel.bind should be the the output of method handleRequest', ()=>{
+    test('second argument to requestsChannel.bind should be the the output of method incrementCount', ()=>{
         function expected(){}
-        jest.spyOn(client, 'handleRequest').mockReturnValue(expected)
+        jest.spyOn(client, 'incrementCount').mockReturnValue(expected)
         client.subscribeToPusher(jest.fn())
         expect(requestBindSpy).toHaveBeenCalledWith(expect.anything(), expected);
     })
 
+    test('second argument to friendsChanel.bind should be the the output of method decrementCount', ()=>{
+        function expected(){}
+        jest.spyOn(client, 'decrementCount').mockReturnValue(expected)
+        client.subscribeToPusher(jest.fn())
+        expect(friendBindSpy).toHaveBeenCalledWith(expect.anything(), expected);
+    })
+
     test('argument from subscribeToPusher should be the same passed to handleSpy', ()=>{
         function expected(){}
-        const handleSpy = jest.spyOn(client, 'handleRequest')
+        const incrementCountSpy = jest.spyOn(client, 'incrementCount')
         client.subscribeToPusher(expected)
-        expect(handleSpy).toHaveBeenCalledWith(expected);
+        expect(incrementCountSpy).toHaveBeenCalledWith(expected);
     })
 
     test('first argument passed to friendsChannel.bind should be "new_friend"',()=>{
@@ -116,14 +123,14 @@ describe('PusherClientHandler handleRequest tests', () => {
 
     test('the existing count is 1, so 2 is passed to the setter',()=>{
         client = new PusherClientHandler('stub_id', 1)
-        const func = client.handleRequest(setterSpy)
+        const func = client.incrementCount(setterSpy)
         func()
         expect(setterSpy).toHaveBeenCalledWith(2)
     })
 
     test('the existing count is 8, so 9 is passed to the setter',()=>{
         client = new PusherClientHandler('stub_id', 8)
-        const func = client.handleRequest(setterSpy)
+        const func = client.incrementCount(setterSpy)
         func()
         expect(setterSpy).toHaveBeenCalledWith(9)
     })
@@ -154,7 +161,7 @@ describe('PusherClientHandler return tests', () => {
 
     test('return is a function, it should call unbind with the result of handleRequest',()=>{
         function expected(){}
-        jest.spyOn(client, 'handleRequest').mockReturnValue(expected)
+        jest.spyOn(client, 'incrementCount').mockReturnValue(expected)
         const func = client.subscribeToPusher(jest.fn())
         func()
         expect(unBindSpy).toHaveBeenCalledWith(expect.anything(), expected)

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -157,6 +157,13 @@ describe('PusherClientHandler decrementCount tests', () => {
         expect(setterSpy).toHaveBeenCalledWith(0)
     })
 
+    test('the existing count is 0, dont call the  setter',()=>{
+        client = new PusherClientHandler('stub_id', 0)
+        const func = client.decrementCount(setterSpy)
+        func()
+        expect(setterSpy).not.toHaveBeenCalled()
+    })
+
     test('the existing count is 8, so 7 is passed to the setter',()=>{
         client = new PusherClientHandler('stub_id', 7)
         const func = client.decrementCount(setterSpy)

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -157,7 +157,7 @@ describe('PusherClientHandler decrementCount tests', () => {
         expect(setterSpy).toHaveBeenCalledWith(0)
     })
 
-    test('the existing count is 0, dont call the  setter',()=>{
+    test('the existing count is 0, dont call the setter',()=>{
         client = new PusherClientHandler('stub_id', 0)
         const func = client.decrementCount(setterSpy)
         func()
@@ -173,7 +173,8 @@ describe('PusherClientHandler decrementCount tests', () => {
 })
 
 describe('PusherClientHandler return tests', () => {
-    let unBindSpy: jest.SpyInstance;
+    let requestsUnbindSpy: jest.SpyInstance;
+    let friendsUnbindSpy: jest.SpyInstance;
     let bindSpy: jest.SpyInstance;
     let subscribeSpy: jest.SpyInstance;
     let client: PusherClientHandler;
@@ -182,25 +183,32 @@ describe('PusherClientHandler return tests', () => {
     beforeEach(()=>{
         jest.resetAllMocks();
         bindSpy = jest.fn();
-        unBindSpy = jest.fn();
+        requestsUnbindSpy = jest.fn();
         unsubscribeSpy = jest.fn();
-        subscribeSpy = jest.fn(()=>{return {bind: bindSpy, unbind: unBindSpy}});
+        subscribeSpy = jest.fn(()=>{return {bind: bindSpy, unbind: requestsUnbindSpy}});
         (getPusherClient as jest.Mock).mockReturnValue({subscribe: subscribeSpy, unsubscribe: unsubscribeSpy});
         client = new PusherClientHandler('stub_id', 0)
     })
 
-    test('return is a function, it should call unbind',()=>{
+    test('return is a function, it should call unbind for friend requests',()=>{
         const func = client.subscribeToPusher(jest.fn())
         func()
-        expect(unBindSpy).toHaveBeenCalledWith('incoming_friend_requests', expect.anything())
+        expect(requestsUnbindSpy).toHaveBeenCalledWith('incoming_friend_requests', expect.anything())
     })
+
+    test('return is a function, it should call unbind for new_friend',()=>{
+        const func = client.subscribeToPusher(jest.fn())
+        func()
+        expect(requestsUnbindSpy).toHaveBeenCalledWith('new_friend', expect.anything())
+    })
+
 
     test('return is a function, it should call unbind with the result of handleRequest',()=>{
         function expected(){}
         jest.spyOn(client, 'incrementCount').mockReturnValue(expected)
         const func = client.subscribeToPusher(jest.fn())
         func()
-        expect(unBindSpy).toHaveBeenCalledWith(expect.anything(), expected)
+        expect(requestsUnbindSpy).toHaveBeenCalledWith(expect.anything(), expected)
     })
 
     test('return is a function, it should call unsubscribe on the pusher client',()=>{

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -202,8 +202,15 @@ describe('PusherClientHandler return tests', () => {
         expect(requestsUnbindSpy).toHaveBeenCalledWith('new_friend', expect.anything())
     })
 
+    test('return is a function, it should call unbind with the result of decrementCount',()=>{
+        function expected(){}
+        jest.spyOn(client, 'decrementCount').mockReturnValue(expected)
+        const func = client.subscribeToPusher(jest.fn())
+        func()
+        expect(requestsUnbindSpy).toHaveBeenCalledWith(expect.anything(), expected)
+    })
 
-    test('return is a function, it should call unbind with the result of handleRequest',()=>{
+    test('return is a function, it should call unbind with the result of incrementCount',()=>{
         function expected(){}
         jest.spyOn(client, 'incrementCount').mockReturnValue(expected)
         const func = client.subscribeToPusher(jest.fn())
@@ -217,17 +224,24 @@ describe('PusherClientHandler return tests', () => {
         expect(unsubscribeSpy).toHaveBeenCalled()
     })
 
-    test('return is a function, it should call unsubscribe on the pusher client',()=>{
+    test('return is a function, it should call unsubscribe on the pusher client friend requests',()=>{
         const client = new PusherClientHandler('54321', 0)
         const func = client.subscribeToPusher(jest.fn())
         func()
         expect(unsubscribeSpy).toHaveBeenCalledWith('user__54321__incoming_friend_requests');
     })
 
-    test('return is a function, it should call unsubscribe on the pusher client',()=>{
+    test('return is a function, it should call unsubscribe on the pusher client friend requests',()=>{
         const client = new PusherClientHandler('12345', 0)
         const func = client.subscribeToPusher(jest.fn())
         func()
         expect(unsubscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');
+    })
+
+    test('return is a function, it should call unsubscribe on the pusher clientfriends ',()=>{
+        const client = new PusherClientHandler('54321', 0)
+        const func = client.subscribeToPusher(jest.fn())
+        func()
+        expect(unsubscribeSpy).toHaveBeenCalledWith('user__54321__friends');
     })
 })

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -23,7 +23,13 @@ describe('PusherClientHandler tests', () => {
         expect(subscribeSpy).toHaveBeenCalled();
     })
 
-    test('if the sessionID is 12345, then subscribe is called with user:12345:incoming_friend_requests',()=>{
+    test('if the sessionID is 12345, then subscribe is called with user__12345__friends',()=>{
+        client = new PusherClientHandler('12345', 0)
+        client.subscribeToPusher(jest.fn())
+        expect(subscribeSpy).toHaveBeenCalledWith('user__12345__friends');
+    })
+
+    test('if the sessionID is 12345, then subscribe is called with user__12345__incoming_friend_requests',()=>{
         client = new PusherClientHandler('12345', 0)
         client.subscribeToPusher(jest.fn())
         expect(subscribeSpy).toHaveBeenCalledWith('user__12345__incoming_friend_requests');

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -165,10 +165,10 @@ describe('PusherClientHandler decrementCount tests', () => {
     })
 
     test('the existing count is 8, so 7 is passed to the setter',()=>{
-        client = new PusherClientHandler('stub_id', 7)
+        client = new PusherClientHandler('stub_id', 8)
         const func = client.decrementCount(setterSpy)
         func()
-        expect(setterSpy).toHaveBeenCalledWith(9)
+        expect(setterSpy).toHaveBeenCalledWith(7)
     })
 })
 

--- a/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
+++ b/__tests__/components/FriendRequestSidebarOptions/helpers.test.ts
@@ -57,6 +57,7 @@ describe('PusherClientHandler bind tests', () => {
     beforeEach(()=>{
         jest.resetAllMocks();
         requestBindSpy = jest.fn();
+        friendBindSpy = jest.fn();
         subscribeSpy = jest.fn((channel: string)=>{
             if (channel.endsWith('requests')){
                 return {bind: requestBindSpy}

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request):Promise<Response> {
         return respond('No Existing Friend Request', 400);
     }
 
-    await handler.addtoFriendsTabeles();
+    await handler.addToFriendsTables();
     await handler.removeRequestFromTable();
     return new Response('OK');
 }
@@ -55,7 +55,7 @@ class Handler{
         return  fetchRedis('sismember', table, this.idToAdd);
     }
 
-    async addtoFriendsTabeles():Promise<void>{
+    async addToFriendsTables():Promise<void>{
         await this.addToFriendsTable(this.userId, this.idToAdd);
         await this.addToFriendsTable(this.idToAdd, this.userId);
     }
@@ -97,8 +97,7 @@ async function getIdToAdd(request: Request):Promise<string | boolean> {
     try{
         const { id: idToAdd } =  z.object({id: z.string()}).parse(body);
         return idToAdd;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    }catch(error){
+    }catch{
         return false;
     }
 }

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -47,7 +47,8 @@ class Handler{
 
     async triggerPusher(){
         const pusherServer = getPusherServer()
-        const user = await fetchRedis('get')
+        const user = await fetchRedis('get', 'user:1966')
+        console.log(user)
         const channel = QueryBuilder.friendsPusher(this.idToAdd)
         await pusherServer.trigger(channel, 'new_friend',user)
     }

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -47,9 +47,11 @@ class Handler{
 
     async triggerPusher(){
         const pusherServer = getPusherServer()
-        const user = await fetchRedis('get', 'user:' + this.userId)
+        const user = await fetchRedis('get', QueryBuilder.user(this.userId))
+        const friend = await fetchRedis('get', QueryBuilder.user(this.idToAdd));
         const channel = QueryBuilder.friendsPusher(this.idToAdd)
         await pusherServer.trigger(channel, 'new_friend',user)
+        await pusherServer.trigger(QueryBuilder.friendsPusher(this.userId), 'new_friend',friend)
     }
 
     async areFriends(): Promise<boolean>{

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -48,7 +48,6 @@ class Handler{
     async triggerPusher(){
         const pusherServer = getPusherServer()
         const user = await fetchRedis('get', 'user:1966')
-        console.log(user)
         const channel = QueryBuilder.friendsPusher(this.idToAdd)
         await pusherServer.trigger(channel, 'new_friend',user)
     }

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: Request):Promise<Response> {
     }
 
     const pusherServer = getPusherServer()
-    await pusherServer.trigger(QueryBuilder.friendsPusher('12345'), 'stub', 'stub')
+    await pusherServer.trigger(QueryBuilder.friendsPusher(idToAdd), 'stub', 'stub')
     await handler.addToFriendsTables();
     await handler.removeRequestFromTable();
     return new Response('OK');

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -3,6 +3,7 @@ import myGetServerSession from "@/lib/myGetServerSession";
 import fetchRedis from "@/helpers/redis";
 import {db} from "@/lib/db";
 import QueryBuilder from "@/lib/queryBuilder";
+import {getPusherServer} from "@/lib/pusher";
 
 export async function POST(request: Request):Promise<Response> {
     const idToAdd = await getIdToAdd(request);
@@ -29,6 +30,8 @@ export async function POST(request: Request):Promise<Response> {
         return respond('No Existing Friend Request', 400);
     }
 
+    const pusherServer = getPusherServer()
+    await pusherServer.trigger("user__12345__friends", 'stub', 'stub')
     await handler.addToFriendsTables();
     await handler.removeRequestFromTable();
     return new Response('OK');

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -47,12 +47,14 @@ class Handler{
 
     async triggerPusher(){
         const pusherServer = getPusherServer()
-        await pusherServer.trigger(QueryBuilder.friendsPusher(this.idToAdd), 'new_friend', {
+        const user ={
             name: 'Adam',
             email: 'adam@batcave.com',
             image: 'stub',
             id: '1966'
-        })
+        }
+        const channel = QueryBuilder.friendsPusher(this.idToAdd)
+        await pusherServer.trigger(channel, 'new_friend',user)
     }
 
     async areFriends(): Promise<boolean>{

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -47,7 +47,12 @@ class Handler{
 
     async triggerPusher(){
         const pusherServer = getPusherServer()
-        await pusherServer.trigger(QueryBuilder.friendsPusher(this.idToAdd), 'new_friend', 'stub')
+        await pusherServer.trigger(QueryBuilder.friendsPusher(this.idToAdd), 'new_friend', {
+            name: 'Adam',
+            email: 'adam@batcave.com',
+            image: 'stub',
+            id: '1966'
+        })
     }
 
     async areFriends(): Promise<boolean>{

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -30,8 +30,7 @@ export async function POST(request: Request):Promise<Response> {
         return respond('No Existing Friend Request', 400);
     }
 
-    const pusherServer = getPusherServer()
-    await pusherServer.trigger(QueryBuilder.friendsPusher(idToAdd as string), 'new_friend', 'stub')
+    await handler.triggerPusher()
     await handler.addToFriendsTables();
     await handler.removeRequestFromTable();
     return new Response('OK');
@@ -44,6 +43,11 @@ class Handler{
     constructor(idToAdd: string, userId: string) {
         this.idToAdd = idToAdd;
         this.userId = userId;
+    }
+
+    async triggerPusher(){
+        const pusherServer = getPusherServer()
+        await pusherServer.trigger(QueryBuilder.friendsPusher(this.idToAdd), 'new_friend', 'stub')
     }
 
     async areFriends(): Promise<boolean>{

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: Request):Promise<Response> {
     }
 
     const pusherServer = getPusherServer()
-    await pusherServer.trigger("user__12345__friends", 'stub', 'stub')
+    await pusherServer.trigger(QueryBuilder.friendsPusher('12345'), 'stub', 'stub')
     await handler.addToFriendsTables();
     await handler.removeRequestFromTable();
     return new Response('OK');

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: Request):Promise<Response> {
     }
 
     const pusherServer = getPusherServer()
-    await pusherServer.trigger(QueryBuilder.friendsPusher(idToAdd), 'stub', 'stub')
+    await pusherServer.trigger(QueryBuilder.friendsPusher(idToAdd as string), 'stub', 'stub')
     await handler.addToFriendsTables();
     await handler.removeRequestFromTable();
     return new Response('OK');

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -12,7 +12,7 @@ export async function POST(request: Request):Promise<Response> {
         return respond('Invalid Request', 422);
     }
 
-    const  userId = await getUserId();
+    const userId = await getUserId();
     if (!userId) {
         return respond('Unauthorized', 401);
     }
@@ -47,12 +47,7 @@ class Handler{
 
     async triggerPusher(){
         const pusherServer = getPusherServer()
-        const user ={
-            name: 'Adam',
-            email: 'adam@batcave.com',
-            image: 'stub',
-            id: '1966'
-        }
+        const user = await fetchRedis('get')
         const channel = QueryBuilder.friendsPusher(this.idToAdd)
         await pusherServer.trigger(channel, 'new_friend',user)
     }

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -47,7 +47,7 @@ class Handler{
 
     async triggerPusher(){
         const pusherServer = getPusherServer()
-        const user = await fetchRedis('get', 'user:1966')
+        const user = await fetchRedis('get', 'user:' + this.userId)
         const channel = QueryBuilder.friendsPusher(this.idToAdd)
         await pusherServer.trigger(channel, 'new_friend',user)
     }

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: Request):Promise<Response> {
     }
 
     const pusherServer = getPusherServer()
-    await pusherServer.trigger(QueryBuilder.friendsPusher(idToAdd as string), 'stub', 'stub')
+    await pusherServer.trigger(QueryBuilder.friendsPusher(idToAdd as string), 'new_friend', 'stub')
     await handler.addToFriendsTables();
     await handler.removeRequestFromTable();
     return new Response('OK');

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -103,7 +103,7 @@ class PusherServerWrapper {
     async trigger(senderId: string, recipientId: string){
         const channel = QueryBuilder.friendsPusher(senderId)
         const user = await fetchRedis('get', QueryBuilder.user(recipientId))
-        await this.pusher.trigger(channel, 'new_friend',user)
+        await this.pusher.trigger(channel, QueryBuilder.new_friend, user)
     }
 }
 

--- a/src/components/SidebarChatList.tsx
+++ b/src/components/SidebarChatList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, {FC, useState} from "react";
+import React, {FC, useEffect, useState} from "react";
 import SidebarChatListItem from "@/components/SidebarChatListItem";
 interface SidebarChatListProps {
     friends: User[],
@@ -8,8 +8,12 @@ interface SidebarChatListProps {
 }
 
 const SidebarChatList:FC<SidebarChatListProps> = ({friends, sessionId})=>{
-    const [activeChats] = useState<User[]>(friends);
+    const [activeChats, setActiveChats] = useState<User[]>(friends);
     const [unseenMessages] = useState<Message[]>([]);
+
+    useEffect(() => {
+        setActiveChats(friends);
+    }, [friends]);
 
     return (<ul key={sessionId} aria-label='chat list'  className='sidebar-chat-list'>
         {activeChats.sort((chatA: User, chatB: User)=>{

--- a/src/components/friendRequestSidebarOptions/FriendRequestSidebarOptions.tsx
+++ b/src/components/friendRequestSidebarOptions/FriendRequestSidebarOptions.tsx
@@ -14,10 +14,9 @@ const FriendRequestSidebarOptions: FC<FRSOProps> = ({initialRequestCount, sessio
     const [requestCount, setRequestCount] = useState<number>(initialRequestCount);
 
     useEffect(()=> {
-        setRequestCount(initialRequestCount)
         const client = new PusherClientHandler(sessionId, requestCount)
         client.subscribeToPusher(setRequestCount)
-    }, [sessionId, requestCount, initialRequestCount]);
+    }, [sessionId, requestCount]);
 
     return <li>
         <Link href='/dashboard/requests' className='link'>

--- a/src/components/friendRequestSidebarOptions/FriendRequestSidebarOptions.tsx
+++ b/src/components/friendRequestSidebarOptions/FriendRequestSidebarOptions.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import {FC, useEffect, useState} from "react";
 import Link from "next/link";
 import {Icons} from "@/components/Icons";
@@ -20,12 +21,12 @@ const FriendRequestSidebarOptions: FC<FRSOProps> = ({initialRequestCount, sessio
 
     return <li>
         <Link href='/dashboard/requests' className='link'>
-        <div className='link-icon group-hover:border-black group-hover:black flex'>
-            <User aria-label="User" className='icon'/>
+            <div className='link-icon group-hover:border-black group-hover:black flex'>
+                <User aria-label="User" className='icon'/>
             </div>
             Friend Requests
             { requestCount > 0 ? <div className="unread-friend-requests-count">{requestCount}</div> : null }
-    </Link>
+        </Link>
     </li>;
 }
 

--- a/src/components/friendRequestSidebarOptions/FriendRequestSidebarOptions.tsx
+++ b/src/components/friendRequestSidebarOptions/FriendRequestSidebarOptions.tsx
@@ -14,9 +14,10 @@ const FriendRequestSidebarOptions: FC<FRSOProps> = ({initialRequestCount, sessio
     const [requestCount, setRequestCount] = useState<number>(initialRequestCount);
 
     useEffect(()=> {
+        setRequestCount(initialRequestCount)
         const client = new PusherClientHandler(sessionId, requestCount)
         client.subscribeToPusher(setRequestCount)
-    }, [sessionId, requestCount]);
+    }, [sessionId, requestCount, initialRequestCount]);
 
     return <li>
         <Link href='/dashboard/requests' className='link'>

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -14,8 +14,9 @@ export default class PusherClientHandler{
     subscribeToPusher(setter: Dispatch<SetStateAction<number>>){
         const client =  getPusherClient()
         const requestsChannelName = QueryBuilder.incomingFriendRequestsPusher(this.id)
+        const friendsChannelName = QueryBuilder.friendsPusher(this.id)
 
-        const friendsChannel = client.subscribe(QueryBuilder.friendsPusher(this.id))
+        const friendsChannel = client.subscribe(friendsChannelName)
         const friendRequestsChannel = client.subscribe(requestsChannelName)
 
         friendsChannel.bind(QueryBuilder.new_friend, ()=>{})

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -13,8 +13,9 @@ export default class PusherClientHandler{
 
     subscribeToPusher(setter: Dispatch<SetStateAction<number>>){
         const client = getPusherClient()
-        client.subscribe(QueryBuilder.friendsPusher(this.id))
+        const friendsChannel = client.subscribe(QueryBuilder.friendsPusher(this.id))
         const requestsChannelName = QueryBuilder.incomingFriendRequestsPusher(this.id)
+        friendsChannel.bind('stub', ()=>{})
         const friendRequestsChannel = client.subscribe(requestsChannelName)
         friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
 

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -7,19 +7,20 @@ export default class PusherClientHandler{
     private readonly count: number;
 
     constructor(id:string, count: number){
-        this.id=id;
-        this.count = count;
+        this.id = id
+        this.count = count
     }
 
     subscribeToPusher(setter: Dispatch<SetStateAction<number>>){
         const client = getPusherClient()
         client.subscribe(QueryBuilder.friendsPusher(this.id))
-        const channel = client.subscribe(QueryBuilder.incomingFriendRequestsPusher(this.id))
-        channel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
+        const requestsChannelName = QueryBuilder.incomingFriendRequestsPusher(this.id)
+        const friendRequestsChannel = client.subscribe(requestsChannelName)
+        friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
 
         return ()=>{
-            channel.unbind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
-            client.unsubscribe(QueryBuilder.incomingFriendRequestsPusher(this.id))
+            friendRequestsChannel.unbind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
+            client.unsubscribe(requestsChannelName)
         }
     }
 

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -13,7 +13,7 @@ export default class PusherClientHandler{
 
     subscribeToPusher(setter: Dispatch<SetStateAction<number>>){
         const client = getPusherClient()
-        client.subscribe(QueryBuilder.friendsPusher('12345'))
+        client.subscribe(QueryBuilder.friendsPusher(this.id))
         const channel = client.subscribe(QueryBuilder.incomingFriendRequestsPusher(this.id))
         channel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
 

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -35,6 +35,8 @@ export default class PusherClientHandler{
     }
 
     decrementCount(func: Dispatch<SetStateAction<number>>){
-        return ()=>{}
+        return ()=>{
+            func(this.count-1)
+        }
     }
 }

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -35,8 +35,11 @@ export default class PusherClientHandler{
     }
 
     decrementCount(func: Dispatch<SetStateAction<number>>){
-        return ()=>{
-            func(this.count-1)
+        if (this.count > 0){
+            return ()=>{
+                func(this.count-1)
+            }
         }
+        return ()=>{}
     }
 }

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -1,45 +1,72 @@
 import {getPusherClient} from "@/lib/pusher";
 import QueryBuilder from "@/lib/queryBuilder";
 import {Dispatch, SetStateAction} from "react";
+import PusherClient, {Channel} from "pusher-js";
 
 export default class PusherClientHandler{
     private readonly count: number;
     private readonly id: string;
+    private readonly client: PusherClient;
+    private readonly channelNames: {requests:string, friends: string}
+    private channels: { requests: Channel; friends: Channel; } | undefined
 
     constructor(id:string, count: number){
         this.id = id
         this.count = count
+        this.client = getPusherClient()
+
+        this.channelNames = {
+            requests:  QueryBuilder.incomingFriendRequestsPusher(this.id),
+            friends: QueryBuilder.friendsPusher(this.id)
+        }
     }
 
     subscribeToPusher(setter: Dispatch<SetStateAction<number>>){
-        const client =  getPusherClient()
-        const requestsChannelName = QueryBuilder.incomingFriendRequestsPusher(this.id)
-        const friendsChannelName = QueryBuilder.friendsPusher(this.id)
-
-        const friendsChannel = client.subscribe(friendsChannelName)
-        const friendRequestsChannel = client.subscribe(requestsChannelName)
-
-        friendsChannel.bind(QueryBuilder.new_friend, this.decrementCount(setter))
-        friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
+        this.subscribeToAllChannels()
+        this.bindAllChannels(setter)
 
         return ()=>{
-            friendsChannel.unbind(QueryBuilder.new_friend, this.decrementCount(setter))
-            friendRequestsChannel.unbind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
-            client.unsubscribe(requestsChannelName)
-            client.unsubscribe(friendsChannelName)
+            this.unbindAllChannels(setter)
+            this.unsubscribeFromAllChannels()
+        }
+    }
+
+    subscribeToAllChannels(){
+        this.channels={
+            friends: this.client.subscribe(this.channelNames.friends),
+            requests: this.client.subscribe(this.channelNames.requests)
+        }
+    }
+
+    unsubscribeFromAllChannels(){
+        this.client.unsubscribe(this.channelNames.friends)
+        this.client.unsubscribe(this.channelNames.requests)
+    }
+
+    bindAllChannels(func: Dispatch<SetStateAction<number>>){
+        if (this.channels){
+            this.channels.friends.bind(QueryBuilder.new_friend, this.decrementCount(func))
+            this.channels.requests.bind(QueryBuilder.incoming_friend_requests, this.incrementCount(func))
+        }
+    }
+
+    unbindAllChannels(func: Dispatch<SetStateAction<number>>){
+        if (this.channels){
+            this.channels.friends.unbind(QueryBuilder.new_friend, this.decrementCount(func))
+            this.channels.requests.unbind(QueryBuilder.incoming_friend_requests, this.incrementCount(func))
         }
     }
 
     incrementCount(func: Dispatch<SetStateAction<number>>){
         return ()=>{
-            func(this.count+1)
+            func(this.count + 1)
         }
     }
 
     decrementCount(func: Dispatch<SetStateAction<number>>){
         if (this.count > 0){
             return ()=>{
-                func(this.count-1)
+                func(this.count - 1)
             }
         }
         return ()=>{}

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -4,11 +4,11 @@ import {Dispatch, SetStateAction} from "react";
 import PusherClient, {Channel} from "pusher-js";
 
 export default class PusherClientHandler{
-    private readonly count: number;
-    private readonly id: string;
-    private readonly client: PusherClient;
+    private readonly count: number
+    private readonly id: string
+    private readonly client: PusherClient
     private readonly channelNames: {requests:string, friends: string}
-    private channels: { requests: Channel; friends: Channel; } | undefined
+    private channels: { requests: Channel, friends: Channel } | undefined
 
     constructor(id:string, count: number){
         this.id = id

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -20,17 +20,21 @@ export default class PusherClientHandler{
         const friendRequestsChannel = client.subscribe(requestsChannelName)
 
         friendsChannel.bind(QueryBuilder.new_friend, ()=>{})
-        friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
+        friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
 
         return ()=>{
-            friendRequestsChannel.unbind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
+            friendRequestsChannel.unbind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
             client.unsubscribe(requestsChannelName)
         }
     }
 
-    handleRequest( func: Dispatch<SetStateAction<number>>){
+    incrementCount(func: Dispatch<SetStateAction<number>>){
         return ()=>{
             func(this.count+1)
         }
+    }
+
+    decrementCount(func: Dispatch<SetStateAction<number>>){
+        return ()=>{}
     }
 }

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -19,7 +19,7 @@ export default class PusherClientHandler{
         const friendsChannel = client.subscribe(friendsChannelName)
         const friendRequestsChannel = client.subscribe(requestsChannelName)
 
-        friendsChannel.bind(QueryBuilder.new_friend, ()=>{})
+        friendsChannel.bind(QueryBuilder.new_friend, this.decrementCount(jest.fn()))
         friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
 
         return ()=>{

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -19,7 +19,7 @@ export default class PusherClientHandler{
         const friendsChannel = client.subscribe(friendsChannelName)
         const friendRequestsChannel = client.subscribe(requestsChannelName)
 
-        friendsChannel.bind(QueryBuilder.new_friend, this.decrementCount())
+        friendsChannel.bind(QueryBuilder.new_friend, this.decrementCount(setter))
         friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
 
         return ()=>{

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -14,6 +14,7 @@ export default class PusherClientHandler{
     subscribeToPusher(setter: Dispatch<SetStateAction<number>>){
         const client = getPusherClient();
         const channel = client.subscribe(QueryBuilder.incomingFriendRequestsPusher(this.id))
+        client.subscribe('user__12345__friends')
         channel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
 
         return ()=>{

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -1,10 +1,11 @@
 import {getPusherClient} from "@/lib/pusher";
 import QueryBuilder from "@/lib/queryBuilder";
 import {Dispatch, SetStateAction} from "react";
+import Pusher from "pusher-js";
 
 export default class PusherClientHandler{
-    private readonly id:string
     private readonly count: number;
+    private readonly id: string;
 
     constructor(id:string, count: number){
         this.id = id
@@ -12,11 +13,13 @@ export default class PusherClientHandler{
     }
 
     subscribeToPusher(setter: Dispatch<SetStateAction<number>>){
-        const client = getPusherClient()
-        const friendsChannel = client.subscribe(QueryBuilder.friendsPusher(this.id))
+        const client =  getPusherClient()
         const requestsChannelName = QueryBuilder.incomingFriendRequestsPusher(this.id)
-        friendsChannel.bind('stub', ()=>{})
+
+        const friendsChannel = client.subscribe(QueryBuilder.friendsPusher(this.id))
         const friendRequestsChannel = client.subscribe(requestsChannelName)
+
+        friendsChannel.bind('stub', ()=>{})
         friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
 
         return ()=>{

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -1,7 +1,6 @@
 import {getPusherClient} from "@/lib/pusher";
 import QueryBuilder from "@/lib/queryBuilder";
 import {Dispatch, SetStateAction} from "react";
-import Pusher from "pusher-js";
 
 export default class PusherClientHandler{
     private readonly count: number;
@@ -19,7 +18,7 @@ export default class PusherClientHandler{
         const friendsChannel = client.subscribe(QueryBuilder.friendsPusher(this.id))
         const friendRequestsChannel = client.subscribe(requestsChannelName)
 
-        friendsChannel.bind('stub', ()=>{})
+        friendsChannel.bind('new_friend', ()=>{})
         friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
 
         return ()=>{

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -23,6 +23,7 @@ export default class PusherClientHandler{
         friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
 
         return ()=>{
+            friendsChannel.unbind(QueryBuilder.new_friend, this.decrementCount(setter))
             friendRequestsChannel.unbind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
             client.unsubscribe(requestsChannelName)
         }

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -26,6 +26,7 @@ export default class PusherClientHandler{
             friendsChannel.unbind(QueryBuilder.new_friend, this.decrementCount(setter))
             friendRequestsChannel.unbind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
             client.unsubscribe(requestsChannelName)
+            client.unsubscribe(friendsChannelName)
         }
     }
 

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -19,7 +19,7 @@ export default class PusherClientHandler{
         const friendsChannel = client.subscribe(friendsChannelName)
         const friendRequestsChannel = client.subscribe(requestsChannelName)
 
-        friendsChannel.bind(QueryBuilder.new_friend, this.decrementCount(jest.fn()))
+        friendsChannel.bind(QueryBuilder.new_friend, this.decrementCount())
         friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.incrementCount(setter))
 
         return ()=>{
@@ -34,7 +34,7 @@ export default class PusherClientHandler{
         }
     }
 
-    decrementCount(func: Dispatch<SetStateAction<number>>){
+    decrementCount(){
         return ()=>{}
     }
 }

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -18,7 +18,7 @@ export default class PusherClientHandler{
         const friendsChannel = client.subscribe(QueryBuilder.friendsPusher(this.id))
         const friendRequestsChannel = client.subscribe(requestsChannelName)
 
-        friendsChannel.bind('new_friend', ()=>{})
+        friendsChannel.bind(QueryBuilder.new_friend, ()=>{})
         friendRequestsChannel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
 
         return ()=>{

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -12,9 +12,9 @@ export default class PusherClientHandler{
     }
 
     subscribeToPusher(setter: Dispatch<SetStateAction<number>>){
-        const client = getPusherClient();
+        const client = getPusherClient()
+        client.subscribe(QueryBuilder.friendsPusher('12345'))
         const channel = client.subscribe(QueryBuilder.incomingFriendRequestsPusher(this.id))
-        client.subscribe('user__12345__friends')
         channel.bind(QueryBuilder.incoming_friend_requests, this.handleRequest(setter))
 
         return ()=>{

--- a/src/components/friendRequestSidebarOptions/helpers.ts
+++ b/src/components/friendRequestSidebarOptions/helpers.ts
@@ -34,7 +34,7 @@ export default class PusherClientHandler{
         }
     }
 
-    decrementCount(){
+    decrementCount(func: Dispatch<SetStateAction<number>>){
         return ()=>{}
     }
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -47,5 +47,4 @@ export default class QueryBuilder {
     static get incoming_friend_requests () {
         return 'incoming_friend_requests'
     }
-
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -16,6 +16,10 @@ export default class QueryBuilder {
         return this.join(userId, 'friends')
     }
 
+    static friendsPusher(userId: string):string{
+        return this.toPusherKey(this.friends(userId))
+    }
+
     static messages(chatId: string):string{
         return this._joinQuery('chat', chatId, 'messages')
     }
@@ -33,10 +37,15 @@ export default class QueryBuilder {
     }
 
     static incomingFriendRequestsPusher(userId: string):string {
-        return this.incomingFriendRequests(userId).replace(/:/g, '__')
+        return this.toPusherKey(this.incomingFriendRequests(userId))
+    }
+
+    static toPusherKey(query: string):string{
+        return query.replace(/:/g, '__')
     }
 
     static get incoming_friend_requests () {
         return 'incoming_friend_requests'
     }
+
 }

--- a/src/lib/queryBuilder.ts
+++ b/src/lib/queryBuilder.ts
@@ -44,6 +44,10 @@ export default class QueryBuilder {
         return query.replace(/:/g, '__')
     }
 
+    static get new_friend (){
+        return 'new_friend'
+    }
+
     static get incoming_friend_requests () {
         return 'incoming_friend_requests'
     }


### PR DESCRIPTION
I corrected the error of the friend request counter and name of recently added friend were not updating live once a friend request had been accepted. This means adding a new pusher channel to make sure the counter updates when a friend request is accepted.

- added trigger for a "new_friends" channel from route
- added subscription for the "new_friends" channel from friendRequestSidebarOptions component
- If the user accepts a friend request, the display count on the side decrements
- refactored QueryBuilder Object for DRY functionality
- refactored sidebarOptions' helper object for organization
- re-titled methods to be specific and self-describing

Even though the new friend requests were updating live when inviting a friend, they weren't updating when the user accepted a friend request, and a page refresh was still necessary. I added another pusher channel for the endpoint to trigger and page to listen for.